### PR TITLE
update CasaOS-Common from v0.4.0 to v0.4.1-alpha1 for the new `notify.Application` struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Curtis-Milo/nat-type-identifier-go v0.0.0-20220215191915-18d42168c63d
-	github.com/IceWhaleTech/CasaOS-Common v0.4.0-alpha1
+	github.com/IceWhaleTech/CasaOS-Common v0.4.1-alpha1
 	github.com/IceWhaleTech/CasaOS-Gateway v0.3.6
 	github.com/ambelovsky/go-structs v1.1.0 // indirect
 	github.com/ambelovsky/gosf v0.0.0-20201109201340-237aea4d6109

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/Curtis-Milo/nat-type-identifier-go v0.0.0-20220215191915-18d42168c63d
 github.com/Curtis-Milo/nat-type-identifier-go v0.0.0-20220215191915-18d42168c63d/go.mod h1:lW9x+yEjqKdPbE3+cf2fGPJXCw/hChX3Omi9QHTLFsQ=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/IceWhaleTech/CasaOS-Common v0.0.0-20220901034123-ca130f6b5ce9/go.mod h1:2MiivEMzvh41codhEKUcn46WK3Ffesop/04qa9jsvQk=
-github.com/IceWhaleTech/CasaOS-Common v0.4.0-alpha1 h1:JeHZAwIriXKGVbaA65FQu/L80nwxb8oF/de5vZp5eHQ=
-github.com/IceWhaleTech/CasaOS-Common v0.4.0-alpha1/go.mod h1:xcemiRsXcs1zrmQxYMyExDjZ7UHYwkJqYE71IDIV0xA=
+github.com/IceWhaleTech/CasaOS-Common v0.4.1-alpha1 h1:lggOJ7WE478DoVlxZV2sxsFe6qP8oxMzQAYHvTcxO3U=
+github.com/IceWhaleTech/CasaOS-Common v0.4.1-alpha1/go.mod h1:xcemiRsXcs1zrmQxYMyExDjZ7UHYwkJqYE71IDIV0xA=
 github.com/IceWhaleTech/CasaOS-Gateway v0.3.6 h1:2tQQo85+jzbbjqIsKKn77QlAA73bc7vZsVCFvWnK4mg=
 github.com/IceWhaleTech/CasaOS-Gateway v0.3.6/go.mod h1:hnZwGUzcOyiufMpVO7l3gu2gAm6Ws4TY4Nlj3kMshXA=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
Signed-off-by: Tiger Wang <tigerwang@outlook.com>