### PR TITLE
Update README.md, Debian 12 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ CasaOS fully supports ZimaBoard, Intel NUC, and Raspberry Pi. Also, more compute
 ### System Compatibility
 
 Official Support
-- Debian 11 (✅ Tested, Recommended)
+- Debian 12 (✅ Tested, Recommended)
 - Ubuntu Server 20.04 (✅ Tested)
 - Raspberry Pi OS (✅ Tested)
 


### PR DESCRIPTION
Now that Debian 12 is stable, IWT's team should check to make sure that CasaOS is stable and then update the wiki