### PR TITLE
Replace satori/go.uuid with google/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/gomodule/redigo v1.8.9
 	github.com/google/go-github/v36 v36.0.0
+	github.com/google/uuid v1.3.0
 	github.com/googollee/go-socket.io v1.7.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/h2non/filetype v1.1.3
@@ -34,7 +35,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.38.1
-	github.com/satori/go.uuid v1.2.0
 	github.com/shirou/gopsutil/v3 v3.23.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
@@ -82,7 +82,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/invopop/yaml v0.2.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,6 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
 github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shirou/gopsutil/v3 v3.23.2 h1:PAWSuiAszn7IhPMBtXsbSCafej7PqUOvY6YywlQUExU=
 github.com/shirou/gopsutil/v3 v3.23.2/go.mod h1:gv0aQw33GLo3pG8SiWKiQrbDzbRY1K80RyZJ7V4Th1M=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/route/v1/file.go
+++ b/route/v1/file.go
@@ -29,7 +29,7 @@ import (
 	model2 "github.com/IceWhaleTech/CasaOS/service/model"
 
 	"github.com/gin-gonic/gin"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/h2non/filetype"
@@ -715,7 +715,7 @@ func PostOperateFileOrDir(c *gin.Context) {
 	list.TotalSize = total
 	list.ProcessedSize = 0
 
-	uid := uuid.NewV4().String()
+	uid := uuid.NewString()
 	service.FileQueue.Store(uid, list)
 	service.OpStrArr = append(service.OpStrArr, uid)
 	if len(service.OpStrArr) == 1 {
@@ -923,7 +923,7 @@ func ConnectWebSocket(c *gin.Context) {
 	peerId := c.Query("peer")
 	writer := c.Writer
 	request := c.Request
-	key := uuid.NewV4().String()
+	key := uuid.NewString()
 	//peerModel := service.MyService.Peer().GetPeerByUserAgent(c.Request.UserAgent())
 	peerModel := model2.PeerDriveDBModel{}
 	name := service.GetName(request)


### PR DESCRIPTION
`github.com/satori/go.uuid` is no longer being actively maintained (last commit was 5 years ago [^1]). So we should just use the newer `github.com/google/uuid`.

[^1]: https://github.com/satori/go.uuid/commits/master/