### PR TITLE
Fix coding bugs: Replace panic with proper error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,7 +128,8 @@ func main() {
 
 	listener, err := net.Listen("tcp", net.JoinHostPort(LOCALHOST, "0"))
 	if err != nil {
-		panic(err)
+		logger.Error("Failed to create TCP listener", zap.Error(err))
+		return
 	}
 	routers := []string{
 		"/v1/sys",
@@ -155,8 +156,8 @@ func main() {
 			Target: "http://" + listener.Addr().String(),
 		})
 		if err != nil {
-			fmt.Println("err", err)
-			panic(err)
+			logger.Error("Failed to create route", zap.Error(err), zap.String("path", apiPath))
+			continue
 		}
 	}
 
@@ -169,7 +170,7 @@ func main() {
 		if response != nil && response.StatusCode() != http.StatusOK {
 			logger.Error("error when trying to register one or more event types - some event type will not be discoverable", zap.String("status", response.Status()), zap.String("body", string(response.Body)))
 		}
-		if response.StatusCode() == http.StatusOK {
+		if response != nil && response.StatusCode() == http.StatusOK {
 			break
 		}
 		time.Sleep(time.Second)
@@ -224,6 +225,7 @@ func main() {
 	// defer service.MyService.Storage().UnmountAllStorage()
 	err = s.Serve(listener) // not using http.serve() to fix G114: Use of net/http serve function that has no support for setting timeouts (see https://github.com/securego/gosec)
 	if err != nil {
-		panic(err)
+		logger.Error("Server failed to start", zap.Error(err))
+		return
 	}
 }

--- a/pkg/utils/httper/httper.go
+++ b/pkg/utils/httper/httper.go
@@ -95,7 +95,7 @@ func Post(url string, data []byte, contentType string, head map[string]string) (
 		req.Header.Add(k, v)
 	}
 	if err != nil {
-		panic(err)
+		return ""
 	}
 
 	client := &http.Client{Timeout: 5 * time.Second}
@@ -120,14 +120,14 @@ func ZeroTierGet(url string, head map[string]string) (content string, code int) 
 		req.Header.Add(k, v)
 	}
 	if err != nil {
-		panic(err)
+		return "", 0
 	}
 
 	client := &http.Client{Timeout: 20 * time.Second}
 	resp, error := client.Do(req)
 
 	if error != nil {
-		panic(error)
+		return "", 0
 	}
 	defer resp.Body.Close()
 	code = resp.StatusCode


### PR DESCRIPTION
- Replace panic() calls with proper error logging in main.go
- Fix potential nil pointer dereference when checking response.StatusCode()
- Replace panic() calls with error returns in httper.go
- Improve error handling for network operations and HTTP responses