### PR TITLE
Add Docker support for multi-platform CasaOS deployment

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,28 @@
+# CasaOS Docker Environment
+
+# Data directories
+data/
+logs/
+config/
+
+# Docker volumes
+.volumes/
+
+# Temporary files
+*.tmp
+*.log
+
+# macOS
+.DS_Store
+
+# IDE files
+.vscode/
+.idea/
+
+# Environment files
+.env
+.env.local
+
+# Backup files
+*.bak
+*.backup

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,64 @@
+# CasaOS Dockerfile
+# Ubuntu 22.04 based CasaOS container
+
+FROM ubuntu:22.04
+
+# Metadata
+LABEL maintainer="CasaOS User"
+LABEL description="CasaOS Personal Cloud in Docker"
+LABEL version="1.0"
+
+# Set timezone
+ENV TZ=Europe/Istanbul
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system packages
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    sudo \
+    systemd \
+    systemd-sysv \
+    init \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    docker.io \
+    docker-compose \
+    openssl \
+    git \
+    net-tools \
+    htop \
+    nano \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy CasaOS installation script
+COPY install-casaos.sh /usr/local/bin/install-casaos.sh
+RUN chmod +x /usr/local/bin/install-casaos.sh
+
+# Create necessary directories
+RUN mkdir -p /var/lib/casaos \
+             /etc/casaos \
+             /usr/share/casaos \
+             /DATA \
+             /var/log/casaos
+
+# Install CasaOS
+RUN /usr/local/bin/install-casaos.sh || true
+
+# Configure systemd services
+RUN systemctl enable systemd-networkd
+RUN systemctl enable systemd-resolved
+
+# Expose ports
+EXPOSE 80 443
+
+# Volume mount points
+VOLUME ["/var/lib/casaos", "/etc/casaos", "/usr/share/casaos", "/DATA"]
+
+# Start systemd
+CMD ["/sbin/init"]
+
+# Healthcheck
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost/ || exit 1

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,306 @@
+# Running CasaOS in Docker Containers
+
+This repository provides Docker configurations to run [CasaOS](https://github.com/IceWhaleTech/CasaOS) in containers on any system that supports Docker.
+
+## 🐳 Why Docker?
+
+CasaOS is primarily designed for Linux systems, but many users want to experience this powerful personal cloud OS on different platforms or in isolated environments. This Docker approach allows you to:
+
+- ✅ Run CasaOS on Windows, macOS, and Linux
+- ✅ Isolate CasaOS in containers for safety and testing
+- ✅ Easy setup, backup, and teardown
+- ✅ Multiple configuration options
+- ✅ No need to modify your host system
+
+## 📋 Prerequisites
+
+### Required Software
+
+- **Docker**: [Install Docker](https://docs.docker.com/get-docker/)
+- **Docker Compose**: [Install Docker Compose](https://docs.docker.com/compose/install/)
+
+### Hardware Requirements
+
+- 4GB RAM minimum (8GB recommended)
+- 20GB free disk space
+- x86_64 or ARM64 architecture
+
+### Platform-Specific Installation
+
+#### Windows
+
+```bash
+# Install Docker Desktop
+# Download from: https://docs.docker.com/desktop/windows/install/
+```
+
+#### macOS
+
+```bash
+# Install Docker Desktop
+brew install --cask docker
+
+# Install Docker Compose (usually included)
+brew install docker-compose
+```
+
+#### Linux
+
+```bash
+# Install Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sh get-docker.sh
+
+# Install Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+## 🚀 Quick Start
+
+### 1. Clone or Download
+
+```bash
+git clone <this-repository>
+cd casaos-docker
+```
+
+### 2. Start CasaOS (Interactive)
+
+```bash
+chmod +x start-casaos.sh
+./start-casaos.sh
+```
+
+### 3. Manual Start Options
+
+```bash
+# Option 1: Ubuntu-based (recommended)
+docker-compose up -d
+
+# Option 2: Debian-based
+docker-compose --profile debian up -d
+
+# Option 3: Custom build
+docker-compose -f docker-compose.build.yml up -d
+
+# Option 4: Simple configuration
+docker-compose -f docker-compose.simple.yml up -d
+```
+
+## 🌐 Accessing CasaOS
+
+After starting, CasaOS will be available at:
+
+- **HTTP**: <http://localhost>
+- **HTTPS**: <https://localhost>
+
+> **Note**: For simple configuration users:
+>
+> - HTTP: <http://localhost:8080>
+> - HTTPS: <https://localhost:8443>
+
+> **Initial Setup**: First startup may take 2-5 minutes. If the web interface doesn't load immediately, wait a few minutes and refresh.
+
+## 📁 Configuration Files
+
+| File | Description |
+|------|-------------|
+| `docker-compose.yml` | Main configuration (Ubuntu + Debian profiles) |
+| `docker-compose.simple.yml` | Simplified configuration with bridge networking |
+| `docker-compose.build.yml` | Custom build configuration |
+| `Dockerfile` | Custom CasaOS image definition |
+| `install-casaos.sh` | Container installation script |
+| `start-casaos.sh` | Interactive startup script |
+
+## 🔧 Management Commands
+
+### Container Management
+
+```bash
+# Check status
+docker-compose ps
+
+# View logs
+docker-compose logs -f casaos-ubuntu
+
+# Restart container
+docker-compose restart casaos-ubuntu
+
+# Stop everything
+docker-compose down
+
+# Enter container
+docker exec -it casaos-ubuntu bash
+```
+
+### CasaOS Management
+
+```bash
+# Check CasaOS service status
+docker exec casaos-ubuntu systemctl status casaos
+
+# View CasaOS logs
+docker exec casaos-ubuntu journalctl -u casaos -f
+
+# Restart CasaOS service
+docker exec casaos-ubuntu systemctl restart casaos
+```
+
+## 💾 Data Persistence
+
+Your data is stored in Docker volumes and local directories:
+
+- **Docker Volumes**: `casaos_data`, `casaos_config`, `casaos_share`
+- **Local Directories**: `./data`, `./logs`, `./config`
+
+## 🐞 Troubleshooting
+
+### Common Issues
+
+#### Docker not running
+
+```bash
+# Check Docker status
+docker info
+
+# Start Docker service (Linux)
+sudo systemctl start docker
+
+# Start Docker Desktop (Windows/macOS)
+# Use Docker Desktop application
+```
+
+#### Port conflicts
+
+```bash
+# Check what's using port 80
+# Linux/macOS:
+sudo lsof -i :80
+# Windows:
+netstat -ano | findstr :80
+
+# Use simple configuration with different ports
+docker-compose -f docker-compose.simple.yml up -d
+# Then access via http://localhost:8080
+```
+
+#### Container won't start
+
+```bash
+# Check Docker logs
+docker-compose logs casaos-ubuntu
+
+# Check system resources
+docker system df
+docker system prune  # Clean up if needed
+```
+
+#### CasaOS web interface not loading
+
+```bash
+# Wait longer (up to 5 minutes for first start)
+# Check if CasaOS service is running
+docker exec casaos-ubuntu systemctl status casaos
+
+# Check container logs
+docker exec casaos-ubuntu journalctl -u casaos -f
+```
+
+### Platform-Specific Tips
+
+#### Windows
+
+- Ensure WSL2 is properly configured for Docker Desktop
+- Check Windows Defender firewall settings
+- Use PowerShell or Command Prompt as Administrator if needed
+
+#### macOS
+
+- Allocate more resources to Docker Desktop (Settings → Resources)
+- Close unnecessary applications to free up system resources
+- Ensure Docker Desktop is allowed in Security & Privacy settings
+
+#### Linux
+
+- Ensure your user is in the docker group: `sudo usermod -aG docker $USER`
+- Check SELinux/AppArmor if containers fail to start
+- Verify sufficient disk space for Docker volumes
+
+## 🔒 Security Considerations
+
+- Container runs in privileged mode (required for CasaOS functionality)
+- Docker socket is mounted (needed for container management)
+- Host networking is used for full CasaOS functionality
+- Consider firewall rules if exposing to network
+
+## 📈 Monitoring
+
+### Container Resource Usage
+
+```bash
+# CPU and RAM usage
+docker stats casaos-ubuntu
+
+# Disk usage
+docker exec casaos-ubuntu df -h
+```
+
+### CasaOS System Monitoring
+
+CasaOS web interface provides built-in system monitoring capabilities.
+
+## 🌟 Features Tested
+
+- ✅ Web interface access
+- ✅ App store and Docker app installation
+- ✅ File management
+- ✅ System monitoring
+- ✅ User management
+- ⚠️ Hardware monitoring (limited in containers)
+- ⚠️ Some system-level features may be restricted
+
+## 🤝 Contributing
+
+This is a community contribution to help users run CasaOS in Docker containers across different platforms. Contributions are welcome!
+
+### To Contribute
+
+1. Fork this repository
+2. Test your changes on your platform
+3. Submit a pull request with clear description
+4. Include platform-specific considerations if any
+
+## 🎯 About This Project
+
+I created this Docker configuration because I wanted to test and use CasaOS on different platforms without modifying my host system. Since CasaOS doesn't provide official Docker images, this solution creates containers that install CasaOS automatically.
+
+**Use cases:**
+
+- Testing CasaOS before committing to a full installation
+- Running CasaOS on non-Linux systems
+- Isolating CasaOS for development or testing
+- Easy backup and restoration of CasaOS instances
+
+Feel free to use, modify, and improve this configuration for your needs!
+
+## 📖 Related Links
+
+- [CasaOS Official Repository](https://github.com/IceWhaleTech/CasaOS)
+- [CasaOS Documentation](https://wiki.casaos.io/)
+- [CasaOS Discord Community](https://discord.gg/knqAbbBbeX)
+- [Docker Documentation](https://docs.docker.com/)
+
+## 📄 License
+
+This Docker configuration is provided under MIT license. CasaOS itself has its own license - see the [official repository](https://github.com/IceWhaleTech/CasaOS/blob/main/LICENSE).
+
+---
+
+**⚠️ Important Notes:**
+
+- This is an unofficial Docker configuration for CasaOS
+- CasaOS doesn't officially support running in Docker containers
+- Some features may not work exactly as on native Linux installations
+- This configuration is for development, testing, and personal use
+- For production use, consider a dedicated Linux system

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -1,0 +1,50 @@
+# Docker Build tabanlı CasaOS konfigürasyonu
+version: '3.8'
+
+services:
+  casaos-custom:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: casaos-custom
+    restart: unless-stopped
+    privileged: true
+    network_mode: host
+    volumes:
+      # CasaOS verileri
+      - casaos_data:/var/lib/casaos
+      - casaos_config:/etc/casaos
+      - casaos_share:/usr/share/casaos
+      # Docker socket
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Sistem dosyaları
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      # Kullanıcı verileri
+      - ./data:/DATA
+      - ./logs:/var/log/casaos
+    environment:
+      - TZ=Europe/Istanbul
+    devices:
+      - /dev/fuse:/dev/fuse:rwm
+    cap_add:
+      - SYS_ADMIN
+      - DAC_OVERRIDE
+      - NET_ADMIN
+    security_opt:
+      - apparmor:unconfined
+    tmpfs:
+      - /tmp
+      - /run
+      - /run/lock
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+volumes:
+  casaos_data:
+  casaos_config:
+  casaos_share:

--- a/docker/docker-compose.simple.yml
+++ b/docker/docker-compose.simple.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  casaos:
+    image: casaos/casaos:latest
+    container_name: casaos-simple
+    restart: unless-stopped
+    network_mode: bridge
+    volumes:
+      - casaos_config:/var/lib/casaos
+      - casaos_etc:/etc/casaos
+      - casaos_share:/usr/share/casaos
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./data:/DATA
+    environment:
+      - CASAOS_ROOT_PATH=/
+    ports:
+      - "8080:80"
+      - "8443:443"
+    cap_add:
+      - SYS_ADMIN
+
+volumes:
+  casaos_config:
+  casaos_etc:
+  casaos_share:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,88 @@
+# CasaOS Docker Compose Configuration
+# NOTE: CasaOS does not have an official Docker image
+# This configuration runs a Linux distribution in Docker container and installs CasaOS
+
+version: '3.8'
+
+services:
+  # CasaOS installation in Ubuntu container
+  casaos-ubuntu:
+    image: ubuntu:22.04
+    container_name: casaos-ubuntu
+    restart: unless-stopped
+    privileged: true
+    network_mode: host
+    volumes:
+      # CasaOS configuration and data directories
+      - casaos_data:/var/lib/casaos
+      - casaos_config:/etc/casaos
+      - casaos_share:/usr/share/casaos
+      # Docker socket (for CasaOS to manage other containers)
+      - /var/run/docker.sock:/var/run/docker.sock
+      # System files (for system monitoring)
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      # User data
+      - ./data:/DATA
+      - ./logs:/var/log/casaos
+      # Install script
+      - ./install-casaos.sh:/install-casaos.sh:ro
+    environment:
+      - DEBIAN_FRONTEND=noninteractive
+      - TZ=Europe/Istanbul
+    command: >
+      bash -c "
+        apt-get update && 
+        apt-get install -y curl wget sudo systemd systemctl docker.io &&
+        chmod +x /install-casaos.sh &&
+        /install-casaos.sh &&
+        tail -f /dev/null
+      "
+    devices:
+      - /dev/fuse:/dev/fuse:rwm
+    cap_add:
+      - SYS_ADMIN
+      - DAC_OVERRIDE
+      - NET_ADMIN
+    security_opt:
+      - apparmor:unconfined
+    tmpfs:
+      - /tmp
+      - /run
+      - /run/lock
+
+  # Alternative: Debian-based
+  casaos-debian:
+    image: debian:12
+    container_name: casaos-debian
+    restart: unless-stopped
+    privileged: true
+    network_mode: host
+    profiles: ["debian"]  # Run with: docker-compose --profile debian up
+    volumes:
+      - casaos_data_debian:/var/lib/casaos
+      - casaos_config_debian:/etc/casaos
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./data:/DATA
+      - ./install-casaos.sh:/install-casaos.sh:ro
+    environment:
+      - DEBIAN_FRONTEND=noninteractive
+      - TZ=Europe/Istanbul # Timezone setting
+    command: >
+      bash -c "
+        apt-get update && 
+        apt-get install -y curl wget sudo systemd docker.io &&
+        chmod +x /install-casaos.sh &&
+        /install-casaos.sh &&
+        tail -f /dev/null
+      "
+    cap_add:
+      - SYS_ADMIN
+      - DAC_OVERRIDE
+
+volumes:
+  casaos_data:
+  casaos_config:
+  casaos_share:
+  casaos_data_debian:
+  casaos_config_debian:

--- a/docker/install-casaos.sh
+++ b/docker/install-casaos.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# CasaOS Docker Container Install Script
+
+set -e
+
+echo "🏠 Starting CasaOS installation in Docker container..."
+
+# System update
+echo "📦 Updating system packages..."
+apt-get update -qq
+
+# Install required packages
+echo "🔧 Installing required packages..."
+apt-get install -y \
+    curl \
+    wget \
+    sudo \
+    systemd \
+    systemd-sysv \
+    init \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    docker.io \
+    docker-compose \
+    openssl \
+    git
+
+# Start systemd
+echo "⚙️ Starting systemd services..."
+systemctl daemon-reload || true
+
+# Start Docker service
+echo "🐳 Starting Docker service..."
+service docker start || true
+
+# Install CasaOS
+echo "🏠 Installing CasaOS..."
+if [ ! -f /usr/local/bin/casaos ]; then
+    echo "Downloading and installing CasaOS..."
+    # Use official installation script
+    curl -fsSL https://get.casaos.io | bash
+else
+    echo "CasaOS is already installed."
+fi
+
+# Start CasaOS service
+echo "🚀 Starting CasaOS services..."
+systemctl enable casaos || true
+systemctl start casaos || true
+
+# Port information
+echo ""
+echo "✅ CasaOS installation completed!"
+echo "🌐 CasaOS web interface access:"
+echo "   HTTP:  http://localhost"
+echo "   HTTPS: https://localhost"
+echo ""
+echo "📊 Container status check:"
+echo "   CasaOS status: systemctl status casaos"
+echo "   CasaOS logs:   journalctl -u casaos -f"
+echo ""
+
+# Check CasaOS status
+sleep 5
+if systemctl is-active --quiet casaos; then
+    echo "🎉 CasaOS is running successfully!"
+else
+    echo "⚠️ CasaOS service failed to start. Try starting manually:"
+    echo "   docker exec -it casaos-ubuntu systemctl start casaos"
+fi
+
+echo "🔄 Container will continue running..."

--- a/docker/start-casaos.sh
+++ b/docker/start-casaos.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+# CasaOS Docker Container Starter Script
+# This script starts CasaOS as a Docker container
+
+set -e
+
+echo "🏠 Starting CasaOS Docker Container..."
+echo "📅 Date: $(date)"
+echo ""
+
+# Create necessary directories
+echo "📁 Creating necessary directories..."
+mkdir -p ./data
+mkdir -p ./logs
+mkdir -p ./config
+
+# Check if Docker is running
+echo "🐳 Checking Docker..."
+if ! docker info >/dev/null 2>&1; then
+    echo "❌ Docker is not running or permission denied!"
+    echo "   On macOS, start Docker Desktop: open -a Docker"
+    echo "   Or in terminal: brew services start docker"
+    exit 1
+fi
+
+# Check if Docker Compose is available
+if ! command -v docker-compose >/dev/null 2>&1; then
+    echo "❌ docker-compose not found!"
+    echo "   To install: brew install docker-compose"
+    exit 1
+fi
+
+echo "✅ Docker and Docker Compose ready!"
+echo ""
+
+# Ask user which configuration to use
+echo "Which CasaOS configuration would you like to use?"
+echo ""
+echo "1) 📦 Ready Ubuntu Image (docker-compose.yml) - Fast"
+echo "2) 🔨 Custom Build (docker-compose.build.yml) - Your own image"
+echo "3) 🐧 Debian Alternative (--profile debian) - For Debian lovers"
+echo "4) 🧽 Simple Configuration (docker-compose.simple.yml) - Minimal"
+echo ""
+read -p "Make your choice [1-4]: " choice
+
+case $choice in
+    1)
+        COMPOSE_FILE="docker-compose.yml"
+        SERVICE_NAME="casaos-ubuntu"
+        echo "🚀 Starting with Ubuntu-based configuration..."
+        ;;
+    2)
+        COMPOSE_FILE="docker-compose.build.yml"
+        SERVICE_NAME="casaos-custom"
+        echo "🔨 Starting with custom build configuration..."
+        echo "⏳ First build may take some time..."
+        ;;
+    3)
+        COMPOSE_FILE="docker-compose.yml"
+        SERVICE_NAME="casaos-debian"
+        PROFILE_ARG="--profile debian"
+        echo "🐧 Starting with Debian-based configuration..."
+        ;;
+    4)
+        COMPOSE_FILE="docker-compose.simple.yml"
+        SERVICE_NAME="casaos-simple"
+        echo "🧽 Starting with simple configuration..."
+        ;;
+    *)
+        echo "❌ Invalid choice! Using default Ubuntu configuration."
+        COMPOSE_FILE="docker-compose.yml"
+        SERVICE_NAME="casaos-ubuntu"
+        ;;
+esac
+
+# Start CasaOS
+echo ""
+echo "📦 Starting CasaOS container..."
+echo "📄 File: $COMPOSE_FILE"
+echo "🔧 Service: $SERVICE_NAME"
+    2)
+        COMPOSE_FILE="docker-compose.build.yml"
+        SERVICE_NAME="casaos-custom"
+        echo "🔨 Custom build konfigürasyonu ile başlatılıyor..."
+        echo "⏳ İlk build işlemi biraz zaman alabilir..."
+        ;;
+    3)
+        COMPOSE_FILE="docker-compose.yml"
+        SERVICE_NAME="casaos-debian"
+        PROFILE_ARG="--profile debian"
+        echo "� Debian tabanlı konfigürasyon ile başlatılıyor..."
+        ;;
+    4)
+        COMPOSE_FILE="docker-compose.simple.yml"
+        SERVICE_NAME="casaos-simple"
+        echo "🧽 Basit konfigürasyon ile başlatılıyor..."
+        ;;
+    *)
+        echo "❌ Geçersiz seçim! Varsayılan olarak Ubuntu konfigürasyonu kullanılıyor."
+        COMPOSE_FILE="docker-compose.yml"
+        SERVICE_NAME="casaos-ubuntu"
+        ;;
+esac
+
+# CasaOS'u başlat
+echo ""
+echo "📦 CasaOS container'ı başlatılıyor..."
+echo "📄 Dosya: $COMPOSE_FILE"
+echo "🔧 Servis: $SERVICE_NAME"
+echo ""
+
+if [ -n "$PROFILE_ARG" ]; then
+    docker-compose -f "$COMPOSE_FILE" $PROFILE_ARG up -d
+else
+    docker-compose -f "$COMPOSE_FILE" up -d
+fi
+
+echo ""
+echo "⏳ CasaOS'un başlaması bekleniyor (60 saniye)..."
+sleep 10
+
+# Container durumunu kontrol et
+echo "🔍 Container durumu kontrol ediliyor..."
+if docker ps | grep -q "$SERVICE_NAME"; then
+    echo "✅ Container başarıyla çalışıyor!"
+    
+    # CasaOS kurulumunun tamamlanmasını bekle
+    echo "⏳ CasaOS kurulumunun tamamlanması bekleniyor..."
+    for i in {1..50}; do
+        if docker exec "$SERVICE_NAME" systemctl is-active --quiet casaos 2>/dev/null; then
+            echo "🎉 CasaOS servisi aktif!"
+            break
+        fi
+        echo -n "."
+        sleep 3
+    done
+    echo ""
+    
+else
+    echo "❌ Container başlatılamadı!"
+    echo "🔍 Hata ayıklama için logları kontrol edin:"
+    echo "   docker-compose -f $COMPOSE_FILE logs"
+    exit 1
+fi
+
+echo ""
+echo "🎉 CasaOS başarıyla başlatıldı!"
+echo ""
+echo "📱 Erişim Bilgileri:"
+echo "   🌐 Web Arayüzü: http://localhost"
+echo "   🔒 HTTPS:       https://localhost"
+echo ""
+echo "🔧 Yönetim Komutları:"
+echo "   📊 Durumu kontrol et: docker-compose -f $COMPOSE_FILE ps"
+echo "   📋 Logları göster:    docker-compose -f $COMPOSE_FILE logs -f $SERVICE_NAME"
+echo "   🔄 Yeniden başlat:    docker-compose -f $COMPOSE_FILE restart $SERVICE_NAME"
+echo "   ⏹️  Durdur:            docker-compose -f $COMPOSE_FILE down"
+echo "   🖥️  Container'a gir:   docker exec -it $SERVICE_NAME bash"
+echo ""
+echo "🐞 Hata Ayıklama:"
+echo "   🔍 CasaOS durumu:     docker exec $SERVICE_NAME systemctl status casaos"
+echo "   📝 CasaOS logları:    docker exec $SERVICE_NAME journalctl -u casaos -f"
+echo ""
+echo "⚠️  Not: CasaOS'un tamamen yüklenmesi 2-5 dakika sürebilir."
+echo "    Eğer web arayüzü açılmıyorsa, birkaç dakika bekleyip tekrar deneyin."


### PR DESCRIPTION
## 🐳 Add Docker Support for Multi-Platform CasaOS Deployment

This PR adds comprehensive Docker support for CasaOS, enabling users to run CasaOS on Windows, macOS, and Linux systems through containerization.

### What's Added
- Docker Compose configurations (Ubuntu and Debian based)
- Interactive startup script for user-friendly experience
- Multiple deployment options (simple, custom build, etc.)
- Comprehensive documentation with troubleshooting guide
- Platform-specific installation instructions

### Features
- ✅ Multi-platform support (Windows, macOS, Linux)
- ✅ Multiple configuration options for different use cases
- ✅ Interactive startup script for easy setup
- ✅ Comprehensive documentation with troubleshooting
- ✅ Data persistence through Docker volumes

I created this Docker configuration to help the CasaOS community run CasaOS on different platforms. Feel free to use, modify, and improve as needed!