### PR TITLE
Fix broken Samba user management functions in helper.sh

### DIFF
--- a/build/sysroot/usr/share/casaos/shell/helper.sh
+++ b/build/sysroot/usr/share/casaos/shell/helper.sh
@@ -337,11 +337,11 @@ RestartSMBD(){
 }
 
 # edit user password $1:username
-EditSmabaUserPassword(){
+EditSambaUserPassword(){
   $sudo_cmd smbpasswd $1
 }
 
-AddSmabaUser(){
+AddSambaUser(){
   $sudo_cmd useradd $1
   $sudo_cmd smbpasswd -a $1 <<EOF
     $2


### PR DESCRIPTION
Description:
This corrects a typo in the helper script that prevented Samba user management from working.

Functions were originally defined as EditSmabaUserPassword and AddSmabaUser.

Because of the misspelling, they were never called, and Samba passwords were not being set.

Changes:

Renamed EditSmabaUserPassword → EditSambaUserPassword

Renamed AddSmabaUser → AddSambaUser

Impact:

Samba password changes and user additions will now function correctly.

No backward-compatibility issues, since nothing was successfully calling the typo’d functions before.

Notes:
This resolves a long-standing bug where Samba accounts were not being properly configured.