### PR TITLE
fix: fallback to displayName when OneDrive email is empty in GetInfo

### DIFF
--- a/drivers/onedrive/drive.go
+++ b/drivers/onedrive/drive.go
@@ -49,7 +49,15 @@ func (d *Onedrive) GetInfo(ctx context.Context) (string, string, string, error) 
 		return "", "", "", err
 	}
 
-	return user.CreatedBy.User.Email, user.ParentReference.DriveID, user.ParentReference.DriveType, nil
+	identity := user.CreatedBy.User.Email
+	if identity == "" {
+		identity = user.CreatedBy.User.DisplayName
+	}
+	if identity == "" {
+		return "", "", "", fmt.Errorf("onedrive: could not determine user identity: createdBy.user.email and createdBy.user.displayName are both empty")
+	}
+
+	return identity, user.ParentReference.DriveID, user.ParentReference.DriveType, nil
 }
 
 func (d *Onedrive) GetSpaceSize(ctx context.Context) (used string, total string, err error) {


### PR DESCRIPTION
While reviewing recent commits, I noticed that `GetInfo` in `drivers/onedrive/drive.go` (introduced in #2101) uses `createdBy.user.email` as the sole identity source. The Microsoft Graph API does not guarantee this field is populated — personal Microsoft accounts frequently omit `email` from the `createdBy` response, returning only `displayName`.

When `email` is empty, `GetInfo` silently returns an empty string as the username. Downstream in `route/v1/recover.go`, this causes the storage config to be created with an empty `dmap["username"]`, which makes duplicate-detection (`cf["username"] == dmap["username"]`) unreliable and results in a broken mount at `/mnt/_onedrive_<timestamp>`.

**Root cause**

```go
// drivers/onedrive/drive.go:52 — current code
return user.CreatedBy.User.Email, user.ParentReference.DriveID, user.ParentReference.DriveType, nil
```

`Info.CreatedBy.User` already has both `Email` and `DisplayName` fields (defined in `meta.go`). The fix uses `Email` when available and falls back to `DisplayName`, returning an error only when both are empty so the caller can surface a meaningful message instead of silently storing a broken config.

**Fix**

```go
identity := user.CreatedBy.User.Email
if identity == "" {
    identity = user.CreatedBy.User.DisplayName
}
if identity == "" {
    return "", "", "", fmt.Errorf("onedrive: could not determine user identity: createdBy.user.email and createdBy.user.displayName are both empty")
}
return identity, user.ParentReference.DriveID, user.ParentReference.DriveType, nil
```

**Edge cases verified**

Tested using the exact `Info` struct from `meta.go` with simulated Microsoft Graph API responses in Docker (`golang:1.21-alpine`):

| Input | Old behavior (username) | New behavior (username) |
|---|---|---|
| Work/school account — email present | `"john@contoso.com"` | `"john@contoso.com"` (unchanged) |
| Personal account — email absent, displayName present | `""` (silent) | `"John Personal"` (fallback used) |
| Both email and displayName empty | `""` (silent) | error returned to caller |
| `createdBy` field missing entirely | `""` (silent) | error returned to caller |
| `parentReference` missing | `"test@contoso.com"` | `"test@contoso.com"` (unchanged) |

**Not tested:** live OneDrive OAuth flow end-to-end (requires valid credentials and running CasaOS instance). The fix only changes the identity-resolution logic inside `GetInfo`; the OAuth token flow and rclone config creation in `recover.go` are not modified.

**Out of scope:** `GetUserInfo` currently returns `("", nil)` unconditionally — that is a separate stub and not changed here.