### PR TITLE
fix: Replace math/rand with crypto/rand for secure random selection

### DIFF
--- a/route/v1/zerotier.go
+++ b/route/v1/zerotier.go
@@ -229,6 +229,31 @@ func GetZTIPs() []gjson.Result {
 	return a.Array()
 }
 
+// calculateIPRange oblicza zakres IP i zwraca ip, start, end, cidr
+func calculateIPRange(selectedCIDR string) (ip, start, end, cidr string) {
+	_, ipNet, err := net.ParseCIDR(selectedCIDR)
+	if err != nil {
+		logger.Error("ParseCIDR error", zap.Error(err))
+		return
+	}
+	cidr = selectedCIDR
+	startIP := ipNet.IP
+	endIP := make(net.IP, len(startIP))
+	copy(endIP, startIP)
+
+	for i := range startIP {
+		endIP[i] |= ^ipNet.Mask[i]
+	}
+	startIP[3] = 1
+	start = startIP.String()
+	endIP[3] = 254
+	end = endIP.String()
+	ipt := ipNet
+	ipt.IP[3] = 1
+	ip = ipt.IP.String()
+	return
+}
+
 func getZTIP(routes string) (ip, start, end, cidr string) {
 	excluded := GetZTIPs()
 	cidrs := []string{
@@ -281,63 +306,19 @@ func getZTIP(routes string) (ip, start, end, cidr string) {
 		}
 	}
 
-	ip = ""
-	if len(filteredCidrs) > 0 {
-		// Użyj crypto/rand zamiast math/rand dla bezpiecznego losowania
-		max := big.NewInt(int64(len(filteredCidrs)))
-		randomIndexBig, err := rand.Int(rand.Reader, max)
-		if err != nil {
-			logger.Error("crypto rand error", zap.Error(err))
-			// Fallback: użyj pierwszego dostępnego CIDR
-			selectedCIDR := filteredCidrs[0]
-			_, ipNet, err := net.ParseCIDR(selectedCIDR)
-			if err != nil {
-				logger.Error("ParseCIDR error", zap.Error(err))
-				return
-			}
-			cidr = selectedCIDR
-			startIP := ipNet.IP
-			endIP := make(net.IP, len(startIP))
-			copy(endIP, startIP)
-
-			for i := range startIP {
-				endIP[i] |= ^ipNet.Mask[i]
-			}
-			startIP[3] = 1
-			start = startIP.String()
-			endIP[3] = 254
-			end = endIP.String()
-			ipt := ipNet
-			ipt.IP[3] = 1
-			ip = ipt.IP.String()
-			return
-		}
-		
-		randomIndex := int(randomIndexBig.Int64())
-		selectedCIDR := filteredCidrs[randomIndex]
-		_, ipNet, err := net.ParseCIDR(selectedCIDR)
-		if err != nil {
-			logger.Error("ParseCIDR error", zap.Error(err))
-			return
-		}
-		cidr = selectedCIDR
-		startIP := ipNet.IP
-		endIP := make(net.IP, len(startIP))
-		copy(endIP, startIP)
-
-		for i := range startIP {
-			endIP[i] |= ^ipNet.Mask[i]
-		}
-		startIP[3] = 1
-		start = startIP.String()
-		endIP[3] = 254
-		end = endIP.String()
-		ipt := ipNet
-		ipt.IP[3] = 1
-		ip = ipt.IP.String()
-		return
-	} else {
+	if len(filteredCidrs) == 0 {
 		logger.Error("No available CIDR found")
+		return
 	}
-	return
+
+	// Wybierz losowy CIDR używając crypto/rand
+	max := big.NewInt(int64(len(filteredCidrs)))
+	randomIndexBig, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		logger.Error("crypto rand error, using first available CIDR", zap.Error(err))
+		return calculateIPRange(filteredCidrs[0])
+	}
+
+	randomIndex := int(randomIndexBig.Int64())
+	return calculateIPRange(filteredCidrs[randomIndex])
 }

--- a/route/v1/zerotier.go
+++ b/route/v1/zerotier.go
@@ -1,9 +1,10 @@
 package v1
 
 import (
+	"crypto/rand"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
+	"math/big"
 	"net"
 	"net/http"
 	"strings"
@@ -280,10 +281,39 @@ func getZTIP(routes string) (ip, start, end, cidr string) {
 		}
 	}
 
-	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	ip = ""
 	if len(filteredCidrs) > 0 {
-		randomIndex := rnd.Intn(len(filteredCidrs))
+		// Użyj crypto/rand zamiast math/rand dla bezpiecznego losowania
+		max := big.NewInt(int64(len(filteredCidrs)))
+		randomIndexBig, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			logger.Error("crypto rand error", zap.Error(err))
+			// Fallback: użyj pierwszego dostępnego CIDR
+			selectedCIDR := filteredCidrs[0]
+			_, ipNet, err := net.ParseCIDR(selectedCIDR)
+			if err != nil {
+				logger.Error("ParseCIDR error", zap.Error(err))
+				return
+			}
+			cidr = selectedCIDR
+			startIP := ipNet.IP
+			endIP := make(net.IP, len(startIP))
+			copy(endIP, startIP)
+
+			for i := range startIP {
+				endIP[i] |= ^ipNet.Mask[i]
+			}
+			startIP[3] = 1
+			start = startIP.String()
+			endIP[3] = 254
+			end = endIP.String()
+			ipt := ipNet
+			ipt.IP[3] = 1
+			ip = ipt.IP.String()
+			return
+		}
+		
+		randomIndex := int(randomIndexBig.Int64())
 		selectedCIDR := filteredCidrs[randomIndex]
 		_, ipNet, err := net.ParseCIDR(selectedCIDR)
 		if err != nil {


### PR DESCRIPTION
Security fix for go:S2245 - Pseudorandom number generators (PRNGs) should not be used in security contexts.

Replaced math/rand with crypto/rand for selecting CIDR ranges when configuring ZeroTier networks.

The previous implementation used math/rand with time-based seeding, which is predictable and could lead to:
- IP address collisions
- Predictable network assignments
- Potential security reconnaissance vectors

The new implementation:
- Uses crypto/rand for cryptographically secure random numbers
- Includes fallback to first available CIDR if crypto/rand fails
- Maintains the same functionality with improved security

This is particularly important as ZeroTier creates VPN/VLAN networks where IP assignment security matters.