### PR TITLE
fix: resolve Ubuntu 26 setup fallback

### DIFF
--- a/build/scripts/setup/script.d/03-setup-casaos.sh
+++ b/build/scripts/setup/script.d/03-setup-casaos.sh
@@ -7,37 +7,50 @@ BUILD_PATH=$(dirname "${BASH_SOURCE[0]}")/../../..
 APP_NAME_SHORT=casaos
 
 __get_setup_script_directory_by_os_release() {
-	pushd "$(dirname "${BASH_SOURCE[0]}")/../service.d/${APP_NAME_SHORT}" >/dev/null
+	local service_directory
+	local os_release_file
+	local candidate
+	local distro
+	local candidates=()
 
-	{
-		# shellcheck source=/dev/null
-		{
-			source /etc/os-release
-			{
-				pushd "${ID}"/"${VERSION_CODENAME}" >/dev/null
-			} || {
-				pushd "${ID}" >/dev/null
-			} || {
-                [[ -n ${ID_LIKE} ]] && for ID in ${ID_LIKE}; do
-				    pushd "${ID}" >/dev/null && break
-                done
-			} || {
-				echo "Unsupported OS: ${ID} ${VERSION_CODENAME} (${ID_LIKE})"
-				exit 1
-			}
+	if [[ -n ${CASAOS_SETUP_SERVICE_DIRECTORY:-} ]]; then
+		service_directory=$(cd "${CASAOS_SETUP_SERVICE_DIRECTORY}" && pwd -P)
+	else
+		service_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")/../service.d/${APP_NAME_SHORT}" && pwd -P)
+	fi
+	os_release_file=${CASAOS_OS_RELEASE_FILE:-/etc/os-release}
 
-			pwd
+	if [[ ! -r "${os_release_file}" ]]; then
+		echo "Unsupported OS: unable to read ${os_release_file}" >&2
+		return 1
+	fi
 
-			popd >/dev/null
+	# shellcheck source=/dev/null
+	source "${os_release_file}"
 
-		} || {
-			echo "Unsupported OS: unknown"
-			exit 1
-		}
+	if [[ -n ${ID:-} && -n ${VERSION_CODENAME:-} ]]; then
+		candidates+=("${ID}/${VERSION_CODENAME}")
+	fi
+	if [[ -n ${ID:-} ]]; then
+		candidates+=("${ID}")
+	fi
+	for distro in ${ID_LIKE:-}; do
+		if [[ -n ${VERSION_CODENAME:-} ]]; then
+			candidates+=("${distro}/${VERSION_CODENAME}")
+		fi
+		candidates+=("${distro}")
+	done
 
-	}
+	for candidate in "${candidates[@]}"; do
+		if [[ -f "${service_directory}/${candidate}/setup-${APP_NAME_SHORT}.sh" ]]; then
+			cd "${service_directory}/${candidate}"
+			pwd -P
+			return 0
+		fi
+	done
 
-	popd >/dev/null
+	echo "Unsupported OS: ${ID:-unknown} ${VERSION_CODENAME:-unknown} (${ID_LIKE:-})" >&2
+	return 1
 }
 
 SETUP_SCRIPT_DIRECTORY=$(__get_setup_script_directory_by_os_release)


### PR DESCRIPTION
## Summary

- resolve setup assets using distro ID/codename first
- fall back through distro ID and ID_LIKE when a codename-specific directory is unavailable
- keep resolver probing silent so expected fallbacks do not emit `pushd` warnings

## Root cause

Ubuntu 26 identifies as the `resolute` codename, but CasaOS has no `ubuntu/resolute` setup directory. The old lookup treated that expected miss as a shell error instead of falling back to the generic Ubuntu setup.

## Impact

CasaOS setup now selects the existing Ubuntu scripts on Ubuntu 26 without noisy lookup errors, while preserving distro-specific precedence for supported releases.

## Validation

- `bash -n` on the updated setup script
- synthetic Ubuntu 26 (`ubuntu` / `resolute`) resolver check
- native Ubuntu 26.04 arm64 fresh install, reboot, service health, and UI verification
