### PR TITLE
Prepare v0.4.25 external storage updater release

### DIFF
--- a/.github/workflows/casa.yml
+++ b/.github/workflows/casa.yml
@@ -18,7 +18,7 @@ on:
 #    tags:
 #      - 'v*'
 env:
-  REPO_URL: https://github.com/IceWhaleTech/CasaOS.git
+  REPO_URL: https://github.com/alvins82/CasaOS.git
   REPO_BRANCH: main
   PACK_SH_URL: https://raw.githubusercontent.com/jerrykuku/actions-casa/main/pack.sh
   PACK_SH: pack.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,23 +3,77 @@ name: goreleaser
 on:
   push:
     tags:
-      - v*.*.*
+      - "v*.*.*"
 
 permissions:
   contents: write
+
 jobs:
-  call-workflow-passing-data:
-    uses: IceWhaleTech/github/.github/workflows/go_release.yml@main
-    with:
-      project-name: CasaOS
-      file-name: casaos
-    secrets:
-      GoogleID: ${{ secrets.GoogleID }} 
-      GoogleSecret: ${{ secrets.GoogleSecret }}
-      DropboxKey: ${{ secrets.DropboxKey }}
-      DropboxSecret: ${{ secrets.DropboxSecret }}
-      OneDriveID: ${{ secrets.OneDriveID }}
-      OneDriveSecret: ${{ secrets.OneDriveSecret }}
-      OneDrivePublic: ${{ secrets.OneDrivePublic }}
-      OSS_KEY_ID: ${{ secrets.OSS_KEY_ID }}
-      OSS_KEY_SECRET: ${{ secrets.OSS_KEY_SECRET }}
+  release:
+    name: Build and publish CasaOS packages
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build release packages
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          output_dir=/tmp/casaos-release
+          mkdir -p "$output_dir"
+
+          build_target() {
+            local target_arch="$1"
+            local goarch="$2"
+            local goarm="${3:-}"
+            local stage_dir
+            local output_file="$output_dir/linux-${target_arch}-casaos-${RELEASE_TAG}.tar.gz"
+
+            stage_dir="$(mktemp -d)"
+            mkdir -p "$stage_dir/build/sysroot/usr/bin"
+            cp -a build "$stage_dir/"
+
+            CGO_ENABLED=0 \
+              GOOS=linux \
+              GOARCH="$goarch" \
+              GOARM="$goarm" \
+              go build \
+                -buildvcs=false \
+                -trimpath \
+                -tags "musl netgo osusergo" \
+                -ldflags "-s -w -X main.commit=${GITHUB_SHA} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                -o "$stage_dir/build/sysroot/usr/bin/casaos" \
+                .
+
+            tar -C "$stage_dir" -czf "$output_file" build
+            rm -rf "$stage_dir"
+          }
+
+          build_target amd64 amd64
+          build_target arm64 arm64
+          build_target arm-7 arm 7
+          (cd "$output_dir" && sha256sum *.tar.gz > checksums.txt)
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            /tmp/casaos-release/*.tar.gz
+            /tmp/casaos-release/checksums.txt
+          draft: false
+          prerelease: false
+          fail_on_unmatched_files: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "UI"]
 	path = UI
-	url = https://github.com/IceWhaleTech/CasaOS-UI.git
+	url = https://github.com/alvins82/CasaOS-UI.git
 	branch = main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.4.25] - 2026-08-12
+
+### Changed
+
+- [Storage] Keep the system storage branch out of `/DATA` merged storage. External disks now provide the mergerfs branches while system AppData remains available at `/DATA/AppData`, allowing CasaOS to be installed on a flash drive without consuming it as media storage.
+- [Updater] Advance the fork release fallback to `v0.4.25` so installations without a release marker still discover the current fork installer.
+
+### Fixed
+
+- [Storage] Preserve existing system data during merge initialization and restore it safely when the merged view is removed.
+
 ## [0.4.20] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.4.20] - 2026-08-12
+
+### Added
+
+- [File] Added a persisted eye toggle for showing or hiding dot-prefixed files and folders in the main file browser. Visible-item totals now include hidden entries when enabled.
+
+### Changed
+
+- [Build] Switched the tracked UI submodule and build paths to the `alvins82/CasaOS-UI` fork ([CasaOS #12](https://github.com/alvins82/CasaOS/pull/12)).
+
+### Fixed
+
+- [OneDrive] Fall back to `createdBy.user.displayName` when Microsoft Graph omits `createdBy.user.email`, and return a clear error when neither identity field is available ([CasaOS #2530](https://github.com/IceWhaleTech/CasaOS/pull/2530)).
+
 ## [0.4.3]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build: build-ui build-backend
 
 
 build-ui:
-	cd CasaOS-UI && yarn install && yarn build
+	cd UI && yarn install && yarn build
 
 build-backend:
 	export CGO_ENABLED=1;export CGO_LDFLAGS=-static;go build -o ./casa main.go;upx --lzma --best casa

--- a/README.md
+++ b/README.md
@@ -89,12 +89,13 @@ The installer stops and restarts CasaOS services while upgrading, so back up imp
 cat /var/lib/casaos/fork-release
 ```
 
-The command should print the fork release tag installed on the system, such as `v0.4.19` for the current release.
+The command should print the fork release tag installed on the system, such as `v0.4.20` for the current release.
 
 Future updates can be installed from the CasaOS dashboard or by running the same command again. Do not use `get.casaos.io/update` after migrating, because it installs IceWhale's upstream component bundle.
 
 ## Fork Changelog
 
+- **2026-08-12 — [v0.4.20](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.20):** Fixed OneDrive identity resolution by falling back to `createdBy.user.displayName` when Microsoft Graph omits `createdBy.user.email`, and returning a clear error when neither field is available. PR: [CasaOS #2530](https://github.com/IceWhaleTech/CasaOS/pull/2530).
 - **2026-08-11 — [v0.4.19](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.19):** Fixed in-app updates by running the installer outside the CasaOS service process group and preserving upgrade logs. PRs: [CasaOS #9](https://github.com/alvins82/CasaOS/pull/9), [installer #10](https://github.com/alvins82/CasaOS-Install/pull/10).
 - **2026-08-11 — [v0.4.18](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.18):** Made release naming platform-neutral while retaining automatic distro detection and amd64, arm64, and armv7 packages in one installer. PRs: [CasaOS #8](https://github.com/alvins82/CasaOS/pull/8), [installer #9](https://github.com/alvins82/CasaOS-Install/pull/9).
 - **2026-08-11 — [v0.4.17-ubuntu26.3](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.3):** Routed dashboard update discovery and installation through CasaOS-Install releases so upstream updates cannot replace fork patches. PRs: [CasaOS #7](https://github.com/alvins82/CasaOS/pull/7), [installer #8](https://github.com/alvins82/CasaOS-Install/pull/8).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@
     </kbd>
 </p>
 
+## Migrate from official CasaOS
+
+If CasaOS was installed from IceWhale's official installer, you can migrate to a released version of this fork in place. Run the command from an SSH session or a directly attached terminal; do not uninstall CasaOS first.
+
+Choose a tag from the [CasaOS-Install releases](https://github.com/alvins82/CasaOS-Install/releases). For example, to migrate to `v0.4.19`:
+
+```sh
+wget -qO- https://github.com/alvins82/CasaOS-Install/releases/download/v0.4.19/install.sh | sudo bash
+```
+
+Replace `v0.4.19` with the released tag you want. The installer stops and restarts CasaOS services while upgrading, so back up important data first. After it finishes, verify the installed fork release with:
+
+```sh
+cat /var/lib/casaos/fork-release
+```
+
+Future updates can be installed from the CasaOS dashboard or by running the installer for another released tag. Do not use `get.casaos.io/update` after migrating, because it installs IceWhale's upstream component bundle.
+
 ## Fork Changelog
 
 - **2026-08-11 — [v0.4.19](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.19):** Fixed in-app updates by running the installer outside the CasaOS service process group and preserving upgrade logs. PRs: [CasaOS #9](https://github.com/alvins82/CasaOS/pull/9), [installer #10](https://github.com/alvins82/CasaOS-Install/pull/10).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@
     </kbd>
 </p>
 
+## Fork Changelog
+
+This section records the changes maintained by this fork beyond the upstream [IceWhaleTech/CasaOS](https://github.com/IceWhaleTech/CasaOS) project. New entries will be added at the top.
+
+### 2026-08-11 — Ubuntu 26 and current Docker compatibility
+
+- Added Ubuntu Server 26.04 LTS (`resolute`) installation support across CasaOS, Gateway, UserService, LocalStorage, MessageBus, and AppManagement.
+- Updated AppManagement's Docker SDK and Compose dependencies, retaining normal API negotiation for Docker 24 through Docker 29 compatibility.
+- Published native AppManagement and `appfile2compose` binaries for amd64, arm64, and arm/v7.
+- Removed only CasaOS's obsolete Docker minimum-API override while preserving unrelated Docker configuration.
+- Added SHA-256 validation for every fork-owned component and a `components.lock` file recording the exact source revisions.
+- Validated a clean Ubuntu 26.04 ARM64 installation, Docker Compose app lifecycle, CasaOS services, dashboard, catalog, and reboot recovery.
+- Consolidated installation into one supported `install.sh` entrypoint and documented a single OS-neutral installation command.
+- Published the latest tested bundle as [CasaOS-Install v0.4.17-ubuntu26.2](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.2).
+
 ## Why do you need Personal Cloud?
 
 In 2020, the team noticed three important trends:

--- a/README.md
+++ b/README.md
@@ -77,18 +77,7 @@
 
 ## Fork Changelog
 
-This section records the changes maintained by this fork beyond the upstream [IceWhaleTech/CasaOS](https://github.com/IceWhaleTech/CasaOS) project. New entries will be added at the top.
-
-### 2026-08-11 — Ubuntu 26 and current Docker compatibility
-
-- Added Ubuntu Server 26.04 LTS (`resolute`) installation support across CasaOS, Gateway, UserService, LocalStorage, MessageBus, and AppManagement.
-- Updated AppManagement's Docker SDK and Compose dependencies, retaining normal API negotiation for Docker 24 through Docker 29 compatibility.
-- Published native AppManagement and `appfile2compose` binaries for amd64, arm64, and arm/v7.
-- Removed only CasaOS's obsolete Docker minimum-API override while preserving unrelated Docker configuration.
-- Added SHA-256 validation for every fork-owned component and a `components.lock` file recording the exact source revisions.
-- Validated a clean Ubuntu 26.04 ARM64 installation, Docker Compose app lifecycle, CasaOS services, dashboard, catalog, and reboot recovery.
-- Consolidated installation into one supported `install.sh` entrypoint and documented a single OS-neutral installation command.
-- Published the latest tested bundle as [CasaOS-Install v0.4.17-ubuntu26.2](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.2).
+- **2026-08-11 — [v0.4.17-ubuntu26.2](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.2):** Added Ubuntu 26.04 and Docker 24–29 compatibility, multi-architecture patched components, clean-install and reboot validation, and a single-command installer.
 
 ## Why do you need Personal Cloud?
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 
 ## Fork Changelog
 
+- **2026-08-11 — [v0.4.18](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.18):** Made release naming platform-neutral while retaining automatic distro detection and amd64, arm64, and armv7 packages in one installer.
 - **2026-08-11 — [v0.4.17-ubuntu26.3](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.3):** Routed dashboard update discovery and installation through CasaOS-Install releases so upstream updates cannot replace fork patches.
 - **2026-08-11 — [v0.4.17-ubuntu26.2](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.2):** Added Ubuntu 26.04 and Docker 24–29 compatibility, multi-architecture patched components, clean-install and reboot validation, and a single-command installer.
 
@@ -149,7 +150,7 @@ Do not use `get.casaos.io` to install this fork; that endpoint installs IceWhale
 
 ### Update CasaOS
 
-Starting with `v0.4.17-ubuntu26.3`, the CasaOS dashboard checks [CasaOS-Install releases](https://github.com/alvins82/CasaOS-Install/releases) and installs updates from this fork, so upstream updates cannot replace the patched components. You can also repeat the installation command above at any time.
+The CasaOS dashboard checks [CasaOS-Install releases](https://github.com/alvins82/CasaOS-Install/releases) and installs updates from this fork, so upstream updates cannot replace the patched components. Release tags are platform-neutral starting with `v0.4.18`; the installer detects the operating system and architecture at runtime. You can also repeat the installation command above at any time.
 
 Existing `v0.4.17-ubuntu26.2` installations must run the installation command above once to enable the fork-aware updater; future releases can then be applied from the dashboard.
 

--- a/README.md
+++ b/README.md
@@ -89,12 +89,13 @@ The installer stops and restarts CasaOS services while upgrading, so back up imp
 cat /var/lib/casaos/fork-release
 ```
 
-The command should print the fork release tag installed on the system, such as `v0.4.21` for the current release.
+The command should print the fork release tag installed on the system, such as `v0.4.25` for the current release.
 
 Future updates can be installed from the CasaOS dashboard or by running the same command again. Do not use `get.casaos.io/update` after migrating, because it installs IceWhale's upstream component bundle.
 
 ## Fork Changelog
 
+- **2026-08-12 — [v0.4.25](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.25):** Kept system storage out of merged `/DATA` storage while preserving system AppData at `/DATA/AppData`, so installations on flash drives can use external disks for media storage.
 - **2026-08-12 — [v0.4.21](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.21):** Fixed fresh one-line installs and CasaOS Storage Manager merges on mergerfs 2.40, including persistent multi-disk pools on Ubuntu 26. PRs: [LocalStorage #2](https://github.com/alvins82/CasaOS-LocalStorage/pull/2), [LocalStorage #3](https://github.com/alvins82/CasaOS-LocalStorage/pull/3), [installer #11](https://github.com/alvins82/CasaOS-Install/pull/11).
 - **2026-08-12 — [v0.4.20](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.20):** Fixed OneDrive identity resolution by falling back to `createdBy.user.displayName` when Microsoft Graph omits `createdBy.user.email`, and returning a clear error when neither field is available. PR: [CasaOS #2530](https://github.com/IceWhaleTech/CasaOS/pull/2530).
 - **2026-08-11 — [v0.4.19](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.19):** Fixed in-app updates by running the installer outside the CasaOS service process group and preserving upgrade logs. PRs: [CasaOS #9](https://github.com/alvins82/CasaOS/pull/9), [installer #10](https://github.com/alvins82/CasaOS-Install/pull/10).

--- a/README.md
+++ b/README.md
@@ -132,7 +132,13 @@ Community Support
 
 Install this fork with the maintained [CasaOS-Install](https://github.com/alvins82/CasaOS-Install) release so that all component compatibility fixes are included.
 
-The recommended method verifies the installer before running it as root:
+Install the latest stable release with one command:
+
+```sh
+curl -fsSL https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh | sudo bash
+```
+
+This runs the same released `install.sh` on every supported operating system and architecture. For detached checksum verification, download and verify it before running it as root:
 
 ```sh
 curl -fL -o install.sh \
@@ -143,17 +149,11 @@ sha256sum --check install.sh.sha256
 sudo bash install.sh
 ```
 
-For a disposable test system, the shorter form is:
-
-```sh
-curl -fsSL https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh | sudo bash
-```
-
 Do not use `get.casaos.io` to install this fork; that endpoint installs IceWhaleTech's upstream component bundle.
 
 ### Update CasaOS
 
-Updates for this fork are published through [CasaOS-Install releases](https://github.com/alvins82/CasaOS-Install/releases). Until the compatibility changes are available upstream, the upstream UI or `get.casaos.io/update` path may replace patched components. Review the fork's release notes and repeat the verified installation procedure above when applying a newer fork release.
+Updates for this fork are published through [CasaOS-Install releases](https://github.com/alvins82/CasaOS-Install/releases). Until the compatibility changes are available upstream, the upstream UI or `get.casaos.io/update` path may replace patched components. Review the fork's release notes and repeat the installation command above when applying a newer fork release.
 
 To determine version of CasaOS from a terminal session run this command:
 

--- a/README.md
+++ b/README.md
@@ -138,16 +138,7 @@ Install the latest stable release with one command:
 curl -fsSL https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh | sudo bash
 ```
 
-This runs the same released `install.sh` on every supported operating system and architecture. For detached checksum verification, download and verify it before running it as root:
-
-```sh
-curl -fL -o install.sh \
-  https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh
-curl -fL -o install.sh.sha256 \
-  https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh.sha256
-sha256sum --check install.sh.sha256
-sudo bash install.sh
-```
+This runs the same released `install.sh` on every supported operating system and architecture.
 
 Do not use `get.casaos.io` to install this fork; that endpoint installs IceWhaleTech's upstream component bundle.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ CasaOS fully supports ZimaBoard, Intel NUC, and Raspberry Pi. Also, more compute
 
 Official Support
 - Debian 12 (✅ Tested, Recommended)
+- Ubuntu Server 26.04 (✅ Tested by this fork)
 - Ubuntu Server 20.04 (✅ Tested)
 - Raspberry Pi OS (✅ Tested)
 
@@ -129,33 +130,30 @@ Community Support
 
 ### Quick Setup CasaOS
 
-Freshly install a system from the list above and run this command:
+Install this fork with the maintained [CasaOS-Install](https://github.com/alvins82/CasaOS-Install) release so that all component compatibility fixes are included.
+
+The recommended method verifies the installer before running it as root:
 
 ```sh
-wget -qO- https://get.casaos.io | sudo bash
+curl -fL -o install.sh \
+  https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh
+curl -fL -o install.sh.sha256 \
+  https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh.sha256
+sha256sum --check install.sh.sha256
+sudo bash install.sh
 ```
 
-or
+For a disposable test system, the shorter form is:
 
 ```sh
-curl -fsSL https://get.casaos.io | sudo bash
+curl -fsSL https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh | sudo bash
 ```
+
+Do not use `get.casaos.io` to install this fork; that endpoint installs IceWhaleTech's upstream component bundle.
 
 ### Update CasaOS
 
-CasaOS can be updated from the User Interface (UI), via `Settings ... Update`.  
-
-Alternatively it can be updated from a terminal session.  To update from a terminal session, it must be done either from a secure shell (ssh) session to the device or from a directly attached terminal and keyboard to the device running CasaOS, this cannot be done from the terminal via the CasaOS User Interface (UI).  To update to the latest release of CasaOS from a terminal session run this command:
-
-```sh
-wget -qO- https://get.casaos.io/update | sudo bash
-```
-
-or
-
-```sh
-curl -fsSL https://get.casaos.io/update | sudo bash
-```
+Updates for this fork are published through [CasaOS-Install releases](https://github.com/alvins82/CasaOS-Install/releases). Until the compatibility changes are available upstream, the upstream UI or `get.casaos.io/update` path may replace patched components. Review the fork's release notes and repeat the verified installation procedure above when applying a newer fork release.
 
 To determine version of CasaOS from a terminal session run this command:
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 
 ## Fork Changelog
 
+- **2026-08-11 — [v0.4.17-ubuntu26.3](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.3):** Routed dashboard update discovery and installation through CasaOS-Install releases so upstream updates cannot replace fork patches.
 - **2026-08-11 — [v0.4.17-ubuntu26.2](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.2):** Added Ubuntu 26.04 and Docker 24–29 compatibility, multi-architecture patched components, clean-install and reboot validation, and a single-command installer.
 
 ## Why do you need Personal Cloud?
@@ -148,12 +149,14 @@ Do not use `get.casaos.io` to install this fork; that endpoint installs IceWhale
 
 ### Update CasaOS
 
-Updates for this fork are published through [CasaOS-Install releases](https://github.com/alvins82/CasaOS-Install/releases). Until the compatibility changes are available upstream, the upstream UI or `get.casaos.io/update` path may replace patched components. Review the fork's release notes and repeat the installation command above when applying a newer fork release.
+Starting with `v0.4.17-ubuntu26.3`, the CasaOS dashboard checks [CasaOS-Install releases](https://github.com/alvins82/CasaOS-Install/releases) and installs updates from this fork, so upstream updates cannot replace the patched components. You can also repeat the installation command above at any time.
 
-To determine version of CasaOS from a terminal session run this command:
+Existing `v0.4.17-ubuntu26.2` installations must run the installation command above once to enable the fork-aware updater; future releases can then be applied from the dashboard.
+
+To check the installed fork release from a terminal, run:
 
 ```sh
-casaos -v
+cat /var/lib/casaos/fork-release
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 
 ## Fork Changelog
 
+- **2026-08-11 — [v0.4.19](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.19):** Fixed in-app updates by running the installer outside the CasaOS service process group and preserving upgrade logs.
 - **2026-08-11 — [v0.4.18](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.18):** Made release naming platform-neutral while retaining automatic distro detection and amd64, arm64, and armv7 packages in one installer.
 - **2026-08-11 — [v0.4.17-ubuntu26.3](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.3):** Routed dashboard update discovery and installation through CasaOS-Install releases so upstream updates cannot replace fork patches.
 - **2026-08-11 — [v0.4.17-ubuntu26.2](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.2):** Added Ubuntu 26.04 and Docker 24–29 compatibility, multi-architecture patched components, clean-install and reboot validation, and a single-command installer.

--- a/README.md
+++ b/README.md
@@ -77,21 +77,19 @@
 
 ## Migrate from official CasaOS
 
-If CasaOS was installed from IceWhale's official installer, you can migrate to a released version of this fork in place. Run the command from an SSH session or a directly attached terminal; do not uninstall CasaOS first.
-
-Choose a tag from the [CasaOS-Install releases](https://github.com/alvins82/CasaOS-Install/releases). For example, to migrate to `v0.4.19`:
+If CasaOS was installed from IceWhale's official installer, you can migrate to the latest release of this fork in place. Run the command from an SSH session or a directly attached terminal; do not uninstall CasaOS first.
 
 ```sh
-wget -qO- https://github.com/alvins82/CasaOS-Install/releases/download/v0.4.19/install.sh | sudo bash
+curl -fsSL https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh | sudo bash
 ```
 
-Replace `v0.4.19` with the released tag you want. The installer stops and restarts CasaOS services while upgrading, so back up important data first. After it finishes, verify the installed fork release with:
+The installer stops and restarts CasaOS services while upgrading, so back up important data first. After it finishes, verify the installed fork release with:
 
 ```sh
 cat /var/lib/casaos/fork-release
 ```
 
-Future updates can be installed from the CasaOS dashboard or by running the installer for another released tag. Do not use `get.casaos.io/update` after migrating, because it installs IceWhale's upstream component bundle.
+Future updates can be installed from the CasaOS dashboard or by running the same command again. Do not use `get.casaos.io/update` after migrating, because it installs IceWhale's upstream component bundle.
 
 ## Fork Changelog
 

--- a/README.md
+++ b/README.md
@@ -89,12 +89,13 @@ The installer stops and restarts CasaOS services while upgrading, so back up imp
 cat /var/lib/casaos/fork-release
 ```
 
-The command should print the fork release tag installed on the system, such as `v0.4.20` for the current release.
+The command should print the fork release tag installed on the system, such as `v0.4.21` for the current release.
 
 Future updates can be installed from the CasaOS dashboard or by running the same command again. Do not use `get.casaos.io/update` after migrating, because it installs IceWhale's upstream component bundle.
 
 ## Fork Changelog
 
+- **2026-08-12 — [v0.4.21](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.21):** Fixed fresh one-line installs and CasaOS Storage Manager merges on mergerfs 2.40, including persistent multi-disk pools on Ubuntu 26. PRs: [LocalStorage #2](https://github.com/alvins82/CasaOS-LocalStorage/pull/2), [LocalStorage #3](https://github.com/alvins82/CasaOS-LocalStorage/pull/3), [installer #11](https://github.com/alvins82/CasaOS-Install/pull/11).
 - **2026-08-12 — [v0.4.20](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.20):** Fixed OneDrive identity resolution by falling back to `createdBy.user.displayName` when Microsoft Graph omits `createdBy.user.email`, and returning a clear error when neither field is available. PR: [CasaOS #2530](https://github.com/IceWhaleTech/CasaOS/pull/2530).
 - **2026-08-11 — [v0.4.19](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.19):** Fixed in-app updates by running the installer outside the CasaOS service process group and preserving upgrade logs. PRs: [CasaOS #9](https://github.com/alvins82/CasaOS/pull/9), [installer #10](https://github.com/alvins82/CasaOS-Install/pull/10).
 - **2026-08-11 — [v0.4.18](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.18):** Made release naming platform-neutral while retaining automatic distro detection and amd64, arm64, and armv7 packages in one installer. PRs: [CasaOS #8](https://github.com/alvins82/CasaOS/pull/8), [installer #9](https://github.com/alvins82/CasaOS-Install/pull/9).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ The installer stops and restarts CasaOS services while upgrading, so back up imp
 cat /var/lib/casaos/fork-release
 ```
 
+The command should print the fork release tag installed on the system, such as `v0.4.19` for the current release.
+
 Future updates can be installed from the CasaOS dashboard or by running the same command again. Do not use `get.casaos.io/update` after migrating, because it installs IceWhale's upstream component bundle.
 
 ## Fork Changelog

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@
 
 ## Fork Changelog
 
-- **2026-08-11 — [v0.4.19](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.19):** Fixed in-app updates by running the installer outside the CasaOS service process group and preserving upgrade logs.
-- **2026-08-11 — [v0.4.18](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.18):** Made release naming platform-neutral while retaining automatic distro detection and amd64, arm64, and armv7 packages in one installer.
-- **2026-08-11 — [v0.4.17-ubuntu26.3](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.3):** Routed dashboard update discovery and installation through CasaOS-Install releases so upstream updates cannot replace fork patches.
-- **2026-08-11 — [v0.4.17-ubuntu26.2](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.2):** Added Ubuntu 26.04 and Docker 24–29 compatibility, multi-architecture patched components, clean-install and reboot validation, and a single-command installer.
+- **2026-08-11 — [v0.4.19](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.19):** Fixed in-app updates by running the installer outside the CasaOS service process group and preserving upgrade logs. PRs: [CasaOS #9](https://github.com/alvins82/CasaOS/pull/9), [installer #10](https://github.com/alvins82/CasaOS-Install/pull/10).
+- **2026-08-11 — [v0.4.18](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.18):** Made release naming platform-neutral while retaining automatic distro detection and amd64, arm64, and armv7 packages in one installer. PRs: [CasaOS #8](https://github.com/alvins82/CasaOS/pull/8), [installer #9](https://github.com/alvins82/CasaOS-Install/pull/9).
+- **2026-08-11 — [v0.4.17-ubuntu26.3](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.3):** Routed dashboard update discovery and installation through CasaOS-Install releases so upstream updates cannot replace fork patches. PRs: [CasaOS #7](https://github.com/alvins82/CasaOS/pull/7), [installer #8](https://github.com/alvins82/CasaOS-Install/pull/8).
+- **2026-08-11 — [v0.4.17-ubuntu26.2](https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.17-ubuntu26.2):** Added Ubuntu 26.04 and Docker 24–29 compatibility, multi-architecture patched components, clean-install and reboot validation, and a single-command installer. PRs: [CasaOS #1](https://github.com/alvins82/CasaOS/pull/1), [AppManagement #1](https://github.com/alvins82/CasaOS-AppManagement/pull/1), [installer #2](https://github.com/alvins82/CasaOS-Install/pull/2).
 
 ## Why do you need Personal Cloud?
 

--- a/build/scripts/setup/script.d/03-setup-casaos.sh
+++ b/build/scripts/setup/script.d/03-setup-casaos.sh
@@ -7,37 +7,50 @@ BUILD_PATH=$(dirname "${BASH_SOURCE[0]}")/../../..
 APP_NAME_SHORT=casaos
 
 __get_setup_script_directory_by_os_release() {
-	pushd "$(dirname "${BASH_SOURCE[0]}")/../service.d/${APP_NAME_SHORT}" >/dev/null
+	local service_directory
+	local os_release_file
+	local candidate
+	local distro
+	local candidates=()
 
-	{
-		# shellcheck source=/dev/null
-		{
-			source /etc/os-release
-			{
-				pushd "${ID}"/"${VERSION_CODENAME}" >/dev/null
-			} || {
-				pushd "${ID}" >/dev/null
-			} || {
-                [[ -n ${ID_LIKE} ]] && for ID in ${ID_LIKE}; do
-				    pushd "${ID}" >/dev/null && break
-                done
-			} || {
-				echo "Unsupported OS: ${ID} ${VERSION_CODENAME} (${ID_LIKE})"
-				exit 1
-			}
+	if [[ -n ${CASAOS_SETUP_SERVICE_DIRECTORY:-} ]]; then
+		service_directory=$(cd "${CASAOS_SETUP_SERVICE_DIRECTORY}" && pwd -P)
+	else
+		service_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")/../service.d/${APP_NAME_SHORT}" && pwd -P)
+	fi
+	os_release_file=${CASAOS_OS_RELEASE_FILE:-/etc/os-release}
 
-			pwd
+	if [[ ! -r "${os_release_file}" ]]; then
+		echo "Unsupported OS: unable to read ${os_release_file}" >&2
+		return 1
+	fi
 
-			popd >/dev/null
+	# shellcheck source=/dev/null
+	source "${os_release_file}"
 
-		} || {
-			echo "Unsupported OS: unknown"
-			exit 1
-		}
+	if [[ -n ${ID:-} && -n ${VERSION_CODENAME:-} ]]; then
+		candidates+=("${ID}/${VERSION_CODENAME}")
+	fi
+	if [[ -n ${ID:-} ]]; then
+		candidates+=("${ID}")
+	fi
+	for distro in ${ID_LIKE:-}; do
+		if [[ -n ${VERSION_CODENAME:-} ]]; then
+			candidates+=("${distro}/${VERSION_CODENAME}")
+		fi
+		candidates+=("${distro}")
+	done
 
-	}
+	for candidate in "${candidates[@]}"; do
+		if [[ -f "${service_directory}/${candidate}/setup-${APP_NAME_SHORT}.sh" ]]; then
+			cd "${service_directory}/${candidate}"
+			pwd -P
+			return 0
+		fi
+	done
 
-	popd >/dev/null
+	echo "Unsupported OS: ${ID:-unknown} ${VERSION_CODENAME:-unknown} (${ID_LIKE:-})" >&2
+	return 1
 }
 
 SETUP_SCRIPT_DIRECTORY=$(__get_setup_script_directory_by_os_release)

--- a/build/scripts/setup/script.d/03-setup-casaos.sh
+++ b/build/scripts/setup/script.d/03-setup-casaos.sh
@@ -67,3 +67,21 @@ SETUP_SCRIPT_FILEPATH="${SETUP_SCRIPT_DIRECTORY}/${SETUP_SCRIPT_FILENAME}"
 }
 
 echo "✅ ${SETUP_SCRIPT_FILENAME} finished."
+
+CASAOS_CONFIG_FILE=${CASAOS_CONFIG_FILE:-/etc/casaos/casaos.conf}
+FORK_UPDATE_URL=https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh
+FORK_VERSION_URL=https://github.com/alvins82/CasaOS-Install/releases/latest/download/version.json
+
+__set_server_config_value() {
+	local key=$1
+	local value=$2
+
+	if grep -q "^${key}[[:space:]]*=" "${CASAOS_CONFIG_FILE}"; then
+		sed -i "s#^${key}[[:space:]]*=.*#${key} = ${value}#" "${CASAOS_CONFIG_FILE}"
+	else
+		sed -i "/^\[server\]$/a${key} = ${value}" "${CASAOS_CONFIG_FILE}"
+	fi
+}
+
+__set_server_config_value UpdateUrl "${FORK_UPDATE_URL}"
+__set_server_config_value UpdateVersionUrl "${FORK_VERSION_URL}"

--- a/build/sysroot/etc/casaos/casaos.conf.sample
+++ b/build/sysroot/etc/casaos/casaos.conf.sample
@@ -18,5 +18,7 @@ ServerApi = https://api.casaos.io/casaos-api
 Handshake = socket.casaos.io
 Token = 
 USBAutoMount =
+UpdateUrl = https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh
+UpdateVersionUrl = https://github.com/alvins82/CasaOS-Install/releases/latest/download/version.json
 
 [system]

--- a/build/sysroot/usr/share/casaos/shell/update.sh
+++ b/build/sysroot/usr/share/casaos/shell/update.sh
@@ -9,4 +9,4 @@
 ### 
 
 
-curl -fsSL https://raw.githubusercontent.com/IceWhaleTech/get/main/update.sh | bash
+curl -fsSL https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh | bash

--- a/common/constants.go
+++ b/common/constants.go
@@ -1,8 +1,12 @@
 package common
 
 const (
-	SERVICENAME = "casaos"
-	VERSION     = "0.4.15"
-	BODY        = " "
-	RANW_NAME   = "IceWhale-RemoteAccess"
+	SERVICENAME          = "casaos"
+	VERSION              = "0.4.15"
+	BODY                 = " "
+	RANW_NAME            = "IceWhale-RemoteAccess"
+	FORK_RELEASE_VERSION = "v0.4.17-ubuntu26.3"
+	FORK_RELEASE_FILE    = "/var/lib/casaos/fork-release"
+	FORK_VERSION_URL     = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/version.json"
+	FORK_UPDATE_URL      = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh"
 )

--- a/common/constants.go
+++ b/common/constants.go
@@ -5,7 +5,7 @@ const (
 	VERSION              = "0.4.15"
 	BODY                 = " "
 	RANW_NAME            = "IceWhale-RemoteAccess"
-	FORK_RELEASE_VERSION = "v0.4.17-ubuntu26.3"
+	FORK_RELEASE_VERSION = "v0.4.18"
 	FORK_RELEASE_FILE    = "/var/lib/casaos/fork-release"
 	FORK_VERSION_URL     = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/version.json"
 	FORK_UPDATE_URL      = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh"

--- a/common/constants.go
+++ b/common/constants.go
@@ -5,7 +5,7 @@ const (
 	VERSION              = "0.4.15"
 	BODY                 = " "
 	RANW_NAME            = "IceWhale-RemoteAccess"
-	FORK_RELEASE_VERSION = "v0.4.18"
+	FORK_RELEASE_VERSION = "v0.4.19"
 	FORK_RELEASE_FILE    = "/var/lib/casaos/fork-release"
 	FORK_VERSION_URL     = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/version.json"
 	FORK_UPDATE_URL      = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh"

--- a/common/constants.go
+++ b/common/constants.go
@@ -5,7 +5,7 @@ const (
 	VERSION              = "0.4.15"
 	BODY                 = " "
 	RANW_NAME            = "IceWhale-RemoteAccess"
-	FORK_RELEASE_VERSION = "v0.4.20"
+	FORK_RELEASE_VERSION = "v0.4.25"
 	FORK_RELEASE_FILE    = "/var/lib/casaos/fork-release"
 	FORK_VERSION_URL     = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/version.json"
 	FORK_UPDATE_URL      = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh"

--- a/common/constants.go
+++ b/common/constants.go
@@ -5,7 +5,7 @@ const (
 	VERSION              = "0.4.15"
 	BODY                 = " "
 	RANW_NAME            = "IceWhale-RemoteAccess"
-	FORK_RELEASE_VERSION = "v0.4.19"
+	FORK_RELEASE_VERSION = "v0.4.20"
 	FORK_RELEASE_FILE    = "/var/lib/casaos/fork-release"
 	FORK_VERSION_URL     = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/version.json"
 	FORK_UPDATE_URL      = "https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh"

--- a/conf/conf.conf.sample
+++ b/conf/conf.conf.sample
@@ -18,6 +18,8 @@ ServerApi = https://api.casaos.io/casaos-api
 Handshake = socket.casaos.io
 Token = 
 USBAutoMount =
+UpdateUrl = https://github.com/alvins82/CasaOS-Install/releases/latest/download/install.sh
+UpdateVersionUrl = https://github.com/alvins82/CasaOS-Install/releases/latest/download/version.json
 
 [system]
 

--- a/drivers/onedrive/drive.go
+++ b/drivers/onedrive/drive.go
@@ -49,7 +49,15 @@ func (d *Onedrive) GetInfo(ctx context.Context) (string, string, string, error) 
 		return "", "", "", err
 	}
 
-	return user.CreatedBy.User.Email, user.ParentReference.DriveID, user.ParentReference.DriveType, nil
+	identity := user.CreatedBy.User.Email
+	if identity == "" {
+		identity = user.CreatedBy.User.DisplayName
+	}
+	if identity == "" {
+		return "", "", "", fmt.Errorf("onedrive: could not determine user identity: createdBy.user.email and createdBy.user.displayName are both empty")
+	}
+
+	return identity, user.ParentReference.DriveID, user.ParentReference.DriveType, nil
 }
 
 func (d *Onedrive) GetSpaceSize(ctx context.Context) (used string, total string, err error) {

--- a/model/sys_common.go
+++ b/model/sys_common.go
@@ -19,13 +19,14 @@ type SysInfoModel struct {
 
 // 服务配置
 type ServerModel struct {
-	HttpPort     string
-	RunMode      string
-	ServerApi    string
-	LockAccount  bool
-	Token        string
-	USBAutoMount string
-	UpdateUrl    string
+	HttpPort         string
+	RunMode          string
+	ServerApi        string
+	LockAccount      bool
+	Token            string
+	USBAutoMount     string
+	UpdateUrl        string
+	UpdateVersionUrl string
 }
 
 // 服务配置

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -11,6 +11,8 @@
 package version
 
 import (
+	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -18,27 +20,66 @@ import (
 	"github.com/IceWhaleTech/CasaOS/model"
 )
 
+var numericVersionPart = regexp.MustCompile(`[0-9]+`)
+
+func versionParts(value string) ([]uint64, bool) {
+	matches := numericVersionPart.FindAllString(value, -1)
+	if len(matches) == 0 {
+		return nil, false
+	}
+
+	parts := make([]uint64, 0, len(matches))
+	for _, match := range matches {
+		part, err := strconv.ParseUint(match, 10, 64)
+		if err != nil {
+			return nil, false
+		}
+		parts = append(parts, part)
+	}
+	return parts, true
+}
+
+func IsVersionNewer(latest string, current string) bool {
+	latestParts, latestOK := versionParts(latest)
+	currentParts, currentOK := versionParts(current)
+	if !latestOK || !currentOK {
+		return false
+	}
+
+	length := len(latestParts)
+	if len(currentParts) > length {
+		length = len(currentParts)
+	}
+	for i := 0; i < length; i++ {
+		var latestPart uint64
+		var currentPart uint64
+		if i < len(latestParts) {
+			latestPart = latestParts[i]
+		}
+		if i < len(currentParts) {
+			currentPart = currentParts[i]
+		}
+		if latestPart != currentPart {
+			return latestPart > currentPart
+		}
+	}
+	return false
+}
+
+func CurrentVersion() string {
+	return currentVersionFromFile(common.FORK_RELEASE_FILE)
+}
+
+func currentVersionFromFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if installedVersion := strings.TrimSpace(string(data)); installedVersion != "" {
+			return installedVersion
+		}
+	}
+	return common.FORK_RELEASE_VERSION
+}
+
 func IsNeedUpdate(version model.Version) (bool, model.Version) {
-
-	v1 := strings.Split(version.Version, ".")
-
-	v2 := strings.Split(common.VERSION, ".")
-
-	for len(v1) < len(v2) {
-		v1 = append(v1, "0")
-	}
-	for len(v2) < len(v1) {
-		v2 = append(v2, "0")
-	}
-	for i := 0; i < len(v1); i++ {
-		a, _ := strconv.Atoi(v1[i])
-		b, _ := strconv.Atoi(v2[i])
-		if a > b {
-			return true, version
-		}
-		if a < b {
-			return false, version
-		}
-	}
-	return false, version
+	return IsVersionNewer(version.Version, CurrentVersion()), version
 }

--- a/pkg/utils/version/version_test.go
+++ b/pkg/utils/version/version_test.go
@@ -1,0 +1,48 @@
+package version
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/IceWhaleTech/CasaOS/common"
+)
+
+func TestIsVersionNewer(t *testing.T) {
+	tests := []struct {
+		name    string
+		latest  string
+		current string
+		want    bool
+	}{
+		{name: "next bundle", latest: "v0.4.17-ubuntu26.3", current: "v0.4.17-ubuntu26.2", want: true},
+		{name: "double digit bundle", latest: "v0.4.17-ubuntu26.10", current: "v0.4.17-ubuntu26.9", want: true},
+		{name: "next CasaOS version", latest: "v0.4.18-ubuntu26.1", current: "v0.4.17-ubuntu26.9", want: true},
+		{name: "same bundle", latest: "v0.4.17-ubuntu26.3", current: "v0.4.17-ubuntu26.3", want: false},
+		{name: "older bundle", latest: "v0.4.17-ubuntu26.2", current: "v0.4.17-ubuntu26.3", want: false},
+		{name: "missing latest", latest: "", current: "v0.4.17-ubuntu26.3", want: false},
+		{name: "invalid latest", latest: "latest", current: "v0.4.17-ubuntu26.3", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsVersionNewer(test.latest, test.current); got != test.want {
+				t.Fatalf("IsVersionNewer(%q, %q) = %v, want %v", test.latest, test.current, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCurrentVersionFromFile(t *testing.T) {
+	versionFile := filepath.Join(t.TempDir(), "fork-release")
+	if got := currentVersionFromFile(versionFile); got != common.FORK_RELEASE_VERSION {
+		t.Fatalf("missing version file returned %q", got)
+	}
+
+	if err := os.WriteFile(versionFile, []byte("v0.4.17-ubuntu26.4\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := currentVersionFromFile(versionFile); got != "v0.4.17-ubuntu26.4" {
+		t.Fatalf("installed version returned %q", got)
+	}
+}

--- a/pkg/utils/version/version_test.go
+++ b/pkg/utils/version/version_test.go
@@ -15,13 +15,13 @@ func TestIsVersionNewer(t *testing.T) {
 		current string
 		want    bool
 	}{
-		{name: "platform-neutral migration", latest: "v0.4.19", current: "v0.4.17-ubuntu26.3", want: true},
-		{name: "next release", latest: "v0.4.19", current: "v0.4.18", want: true},
-		{name: "next CasaOS minor", latest: "v0.5.0", current: "v0.4.19", want: true},
-		{name: "same release", latest: "v0.4.19", current: "v0.4.19", want: false},
-		{name: "older compatibility release", latest: "v0.4.18", current: "v0.4.19", want: false},
-		{name: "missing latest", latest: "", current: "v0.4.19", want: false},
-		{name: "invalid latest", latest: "latest", current: "v0.4.19", want: false},
+		{name: "platform-neutral migration", latest: "v0.4.20", current: "v0.4.17-ubuntu26.3", want: true},
+		{name: "next release", latest: "v0.4.20", current: "v0.4.19", want: true},
+		{name: "next CasaOS minor", latest: "v0.5.0", current: "v0.4.20", want: true},
+		{name: "same release", latest: "v0.4.20", current: "v0.4.20", want: false},
+		{name: "older compatibility release", latest: "v0.4.19", current: "v0.4.20", want: false},
+		{name: "missing latest", latest: "", current: "v0.4.20", want: false},
+		{name: "invalid latest", latest: "latest", current: "v0.4.20", want: false},
 	}
 
 	for _, test := range tests {
@@ -39,10 +39,10 @@ func TestCurrentVersionFromFile(t *testing.T) {
 		t.Fatalf("missing version file returned %q", got)
 	}
 
-	if err := os.WriteFile(versionFile, []byte("v0.4.19\n"), 0o600); err != nil {
+	if err := os.WriteFile(versionFile, []byte("v0.4.20\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got := currentVersionFromFile(versionFile); got != "v0.4.19" {
+	if got := currentVersionFromFile(versionFile); got != "v0.4.20" {
 		t.Fatalf("installed version returned %q", got)
 	}
 }

--- a/pkg/utils/version/version_test.go
+++ b/pkg/utils/version/version_test.go
@@ -15,13 +15,13 @@ func TestIsVersionNewer(t *testing.T) {
 		current string
 		want    bool
 	}{
-		{name: "platform-neutral migration", latest: "v0.4.18", current: "v0.4.17-ubuntu26.3", want: true},
+		{name: "platform-neutral migration", latest: "v0.4.19", current: "v0.4.17-ubuntu26.3", want: true},
 		{name: "next release", latest: "v0.4.19", current: "v0.4.18", want: true},
-		{name: "next CasaOS minor", latest: "v0.5.0", current: "v0.4.18", want: true},
-		{name: "same release", latest: "v0.4.18", current: "v0.4.18", want: false},
-		{name: "older compatibility release", latest: "v0.4.17-ubuntu26.3", current: "v0.4.18", want: false},
-		{name: "missing latest", latest: "", current: "v0.4.18", want: false},
-		{name: "invalid latest", latest: "latest", current: "v0.4.18", want: false},
+		{name: "next CasaOS minor", latest: "v0.5.0", current: "v0.4.19", want: true},
+		{name: "same release", latest: "v0.4.19", current: "v0.4.19", want: false},
+		{name: "older compatibility release", latest: "v0.4.18", current: "v0.4.19", want: false},
+		{name: "missing latest", latest: "", current: "v0.4.19", want: false},
+		{name: "invalid latest", latest: "latest", current: "v0.4.19", want: false},
 	}
 
 	for _, test := range tests {

--- a/pkg/utils/version/version_test.go
+++ b/pkg/utils/version/version_test.go
@@ -15,13 +15,13 @@ func TestIsVersionNewer(t *testing.T) {
 		current string
 		want    bool
 	}{
-		{name: "next bundle", latest: "v0.4.17-ubuntu26.3", current: "v0.4.17-ubuntu26.2", want: true},
-		{name: "double digit bundle", latest: "v0.4.17-ubuntu26.10", current: "v0.4.17-ubuntu26.9", want: true},
-		{name: "next CasaOS version", latest: "v0.4.18-ubuntu26.1", current: "v0.4.17-ubuntu26.9", want: true},
-		{name: "same bundle", latest: "v0.4.17-ubuntu26.3", current: "v0.4.17-ubuntu26.3", want: false},
-		{name: "older bundle", latest: "v0.4.17-ubuntu26.2", current: "v0.4.17-ubuntu26.3", want: false},
-		{name: "missing latest", latest: "", current: "v0.4.17-ubuntu26.3", want: false},
-		{name: "invalid latest", latest: "latest", current: "v0.4.17-ubuntu26.3", want: false},
+		{name: "platform-neutral migration", latest: "v0.4.18", current: "v0.4.17-ubuntu26.3", want: true},
+		{name: "next release", latest: "v0.4.19", current: "v0.4.18", want: true},
+		{name: "next CasaOS minor", latest: "v0.5.0", current: "v0.4.18", want: true},
+		{name: "same release", latest: "v0.4.18", current: "v0.4.18", want: false},
+		{name: "older compatibility release", latest: "v0.4.17-ubuntu26.3", current: "v0.4.18", want: false},
+		{name: "missing latest", latest: "", current: "v0.4.18", want: false},
+		{name: "invalid latest", latest: "latest", current: "v0.4.18", want: false},
 	}
 
 	for _, test := range tests {
@@ -39,10 +39,10 @@ func TestCurrentVersionFromFile(t *testing.T) {
 		t.Fatalf("missing version file returned %q", got)
 	}
 
-	if err := os.WriteFile(versionFile, []byte("v0.4.17-ubuntu26.4\n"), 0o600); err != nil {
+	if err := os.WriteFile(versionFile, []byte("v0.4.19\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got := currentVersionFromFile(versionFile); got != "v0.4.17-ubuntu26.4" {
+	if got := currentVersionFromFile(versionFile); got != "v0.4.19" {
 		t.Fatalf("installed version returned %q", got)
 	}
 }

--- a/route/v1/system.go
+++ b/route/v1/system.go
@@ -16,7 +16,6 @@ import (
 
 	http2 "github.com/IceWhaleTech/CasaOS-Common/utils/http"
 	"github.com/IceWhaleTech/CasaOS-Common/utils/port"
-	"github.com/IceWhaleTech/CasaOS/common"
 	"github.com/IceWhaleTech/CasaOS/model"
 	"github.com/IceWhaleTech/CasaOS/pkg/config"
 	"github.com/IceWhaleTech/CasaOS/pkg/utils"
@@ -37,11 +36,11 @@ import (
 // @Success 200 {string} string "ok"
 // @Router /sys/version/check [get]
 func GetSystemCheckVersion(ctx echo.Context) error {
-	need, version := version.IsNeedUpdate(service.MyService.Casa().GetCasaosVersion())
+	need, latestVersion := version.IsNeedUpdate(service.MyService.Casa().GetCasaosVersion())
 	if need {
 		installLog := model2.AppNotify{}
 		installLog.State = 0
-		installLog.Message = "New version " + version.Version + " is ready, ready to upgrade"
+		installLog.Message = "New version " + latestVersion.Version + " is ready, ready to upgrade"
 		installLog.Type = types.NOTIFY_TYPE_NEED_CONFIRM
 		installLog.CreatedAt = strconv.FormatInt(time.Now().Unix(), 10)
 		installLog.UpdatedAt = strconv.FormatInt(time.Now().Unix(), 10)
@@ -50,8 +49,8 @@ func GetSystemCheckVersion(ctx echo.Context) error {
 	}
 	data := make(map[string]interface{}, 3)
 	data["need_update"] = need
-	data["version"] = version
-	data["current_version"] = common.VERSION
+	data["version"] = latestVersion
+	data["current_version"] = version.CurrentVersion()
 	return ctx.JSON(common_err.SUCCESS, model.Result{Success: common_err.SUCCESS, Message: common_err.GetMsg(common_err.SUCCESS), Data: data})
 }
 
@@ -63,9 +62,9 @@ func GetSystemCheckVersion(ctx echo.Context) error {
 // @Success 200 {string} string "ok"
 // @Router /sys/update [post]
 func SystemUpdate(ctx echo.Context) error {
-	need, version := version.IsNeedUpdate(service.MyService.Casa().GetCasaosVersion())
+	need, latestVersion := version.IsNeedUpdate(service.MyService.Casa().GetCasaosVersion())
 	if need {
-		service.MyService.System().UpdateSystemVersion(version.Version)
+		service.MyService.System().UpdateSystemVersion(latestVersion.Version)
 	}
 	return ctx.JSON(common_err.SUCCESS, model.Result{Success: common_err.SUCCESS, Message: common_err.GetMsg(common_err.SUCCESS)})
 }
@@ -87,7 +86,7 @@ func GetSystemConfigDebug(ctx echo.Context) error {
 	array := service.MyService.System().GetSystemConfigDebug()
 	disk := service.MyService.System().GetDiskInfo()
 	sys := service.MyService.System().GetSysInfo()
-	version := service.MyService.Casa().GetCasaosVersion()
+	latestVersion := service.MyService.Casa().GetCasaosVersion()
 	var bugContent string = fmt.Sprintf(`
 	 - OS: %s
 	 - CasaOS Version: %s
@@ -97,7 +96,7 @@ func GetSystemConfigDebug(ctx echo.Context) error {
 	 - Remote Version: %s
 	 - Browser: $Browser$ 
 	 - Version: $Version$
-`, sys.OS, common.VERSION, disk.Total>>20, disk.Used>>20, array, version.Version)
+`, sys.OS, version.CurrentVersion(), disk.Total>>20, disk.Used>>20, array, latestVersion.Version)
 
 	//	array = append(array, fmt.Sprintf("disk,total:%v,used:%v,UsedPercent:%v", disk.Total>>20, disk.Used>>20, disk.UsedPercent))
 

--- a/route/v1/system.go
+++ b/route/v1/system.go
@@ -64,7 +64,9 @@ func GetSystemCheckVersion(ctx echo.Context) error {
 func SystemUpdate(ctx echo.Context) error {
 	need, latestVersion := version.IsNeedUpdate(service.MyService.Casa().GetCasaosVersion())
 	if need {
-		service.MyService.System().UpdateSystemVersion(latestVersion.Version)
+		if err := service.MyService.System().UpdateSystemVersion(latestVersion.Version); err != nil {
+			return ctx.JSON(common_err.SERVICE_ERROR, model.Result{Success: common_err.SERVICE_ERROR, Message: err.Error()})
+		}
 	}
 	return ctx.JSON(common_err.SUCCESS, model.Result{Success: common_err.SUCCESS, Message: common_err.GetMsg(common_err.SUCCESS)})
 }

--- a/service/casa.go
+++ b/service/casa.go
@@ -2,8 +2,11 @@ package service
 
 import (
 	json2 "encoding/json"
+	"net/url"
+	"strings"
 	"time"
 
+	"github.com/IceWhaleTech/CasaOS/common"
 	"github.com/IceWhaleTech/CasaOS/model"
 	"github.com/IceWhaleTech/CasaOS/pkg/config"
 	"github.com/IceWhaleTech/CasaOS/pkg/utils/httper"
@@ -16,26 +19,60 @@ type CasaService interface {
 
 type casaService struct{}
 
+func validHTTPSURL(value string) bool {
+	parsed, err := url.ParseRequestURI(value)
+	return err == nil && parsed.Scheme == "https" && parsed.Host != ""
+}
+
+func resolveUpdateVersionURL() string {
+	value := strings.TrimSpace(config.ServerInfo.UpdateVersionUrl)
+	if validHTTPSURL(value) {
+		return value
+	}
+	return common.FORK_VERSION_URL
+}
+
+func parseReleaseVersion(payload string) model.Version {
+	var release model.Version
+	if err := json2.Unmarshal([]byte(payload), &release); err == nil && release.Version != "" {
+		return release
+	}
+
+	data := gjson.Get(payload, "data")
+	if data.Exists() {
+		_ = json2.Unmarshal([]byte(data.String()), &release)
+		if release.Version != "" {
+			return release
+		}
+	}
+
+	return model.Version{
+		Version:   gjson.Get(payload, "tag_name").String(),
+		ChangeLog: gjson.Get(payload, "body").String(),
+	}
+}
+
 /**
  * @description: get remote version
  * @return {model.Version}
  */
 func (o *casaService) GetCasaosVersion() model.Version {
-	keyName := "casa_version"
+	versionURL := resolveUpdateVersionURL()
+	keyName := "casa_version:" + versionURL
 	var dataStr string
 	var version model.Version
 	if result, ok := Cache.Get(keyName); ok {
 		dataStr, ok = result.(string)
 		if ok {
-			data := gjson.Get(dataStr, "data")
-			json2.Unmarshal([]byte(data.String()), &version)
-			return version
+			return parseReleaseVersion(dataStr)
 		}
 	}
 
-	v := httper.OasisGet(config.ServerInfo.ServerApi + "/v1/sys/version")
-	data := gjson.Get(v, "data")
-	json2.Unmarshal([]byte(data.String()), &version)
+	v := httper.Get(versionURL, map[string]string{
+		"Accept":     "application/json",
+		"User-Agent": "CasaOS-Fork-Updater",
+	})
+	version = parseReleaseVersion(v)
 
 	if len(version.Version) > 0 {
 		Cache.Set(keyName, v, time.Minute*20)

--- a/service/casa_test.go
+++ b/service/casa_test.go
@@ -14,9 +14,9 @@ func TestParseReleaseVersion(t *testing.T) {
 		version   string
 		changeLog string
 	}{
-		{name: "release manifest", payload: `{"version":"v0.4.17-ubuntu26.3","change_log":"Fork updater"}`, version: "v0.4.17-ubuntu26.3", changeLog: "Fork updater"},
+		{name: "release manifest", payload: `{"version":"v0.4.18","change_log":"Fork updater"}`, version: "v0.4.18", changeLog: "Fork updater"},
 		{name: "legacy API", payload: `{"data":{"version":"0.4.15","change_log":"Upstream"}}`, version: "0.4.15", changeLog: "Upstream"},
-		{name: "GitHub API", payload: `{"tag_name":"v0.4.17-ubuntu26.3","body":"Release body"}`, version: "v0.4.17-ubuntu26.3", changeLog: "Release body"},
+		{name: "GitHub API", payload: `{"tag_name":"v0.4.18","body":"Release body"}`, version: "v0.4.18", changeLog: "Release body"},
 	}
 
 	for _, test := range tests {

--- a/service/casa_test.go
+++ b/service/casa_test.go
@@ -14,9 +14,9 @@ func TestParseReleaseVersion(t *testing.T) {
 		version   string
 		changeLog string
 	}{
-		{name: "release manifest", payload: `{"version":"v0.4.19","change_log":"Fork updater"}`, version: "v0.4.19", changeLog: "Fork updater"},
+		{name: "release manifest", payload: `{"version":"v0.4.20","change_log":"Fork updater"}`, version: "v0.4.20", changeLog: "Fork updater"},
 		{name: "legacy API", payload: `{"data":{"version":"0.4.15","change_log":"Upstream"}}`, version: "0.4.15", changeLog: "Upstream"},
-		{name: "GitHub API", payload: `{"tag_name":"v0.4.19","body":"Release body"}`, version: "v0.4.19", changeLog: "Release body"},
+		{name: "GitHub API", payload: `{"tag_name":"v0.4.20","body":"Release body"}`, version: "v0.4.20", changeLog: "Release body"},
 	}
 
 	for _, test := range tests {

--- a/service/casa_test.go
+++ b/service/casa_test.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/IceWhaleTech/CasaOS/common"
+	"github.com/IceWhaleTech/CasaOS/pkg/config"
+)
+
+func TestParseReleaseVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   string
+		version   string
+		changeLog string
+	}{
+		{name: "release manifest", payload: `{"version":"v0.4.17-ubuntu26.3","change_log":"Fork updater"}`, version: "v0.4.17-ubuntu26.3", changeLog: "Fork updater"},
+		{name: "legacy API", payload: `{"data":{"version":"0.4.15","change_log":"Upstream"}}`, version: "0.4.15", changeLog: "Upstream"},
+		{name: "GitHub API", payload: `{"tag_name":"v0.4.17-ubuntu26.3","body":"Release body"}`, version: "v0.4.17-ubuntu26.3", changeLog: "Release body"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := parseReleaseVersion(test.payload)
+			if got.Version != test.version || got.ChangeLog != test.changeLog {
+				t.Fatalf("parseReleaseVersion() = %#v, want version %q and changelog %q", got, test.version, test.changeLog)
+			}
+		})
+	}
+}
+
+func TestResolveUpdateVersionURL(t *testing.T) {
+	original := config.ServerInfo.UpdateVersionUrl
+	t.Cleanup(func() { config.ServerInfo.UpdateVersionUrl = original })
+
+	config.ServerInfo.UpdateVersionUrl = "https://example.com/version.json"
+	if got := resolveUpdateVersionURL(); got != "https://example.com/version.json" {
+		t.Fatalf("resolveUpdateVersionURL() = %q", got)
+	}
+
+	config.ServerInfo.UpdateVersionUrl = "not a URL"
+	if got := resolveUpdateVersionURL(); got != common.FORK_VERSION_URL {
+		t.Fatalf("resolveUpdateVersionURL() fallback = %q", got)
+	}
+}

--- a/service/casa_test.go
+++ b/service/casa_test.go
@@ -14,9 +14,9 @@ func TestParseReleaseVersion(t *testing.T) {
 		version   string
 		changeLog string
 	}{
-		{name: "release manifest", payload: `{"version":"v0.4.18","change_log":"Fork updater"}`, version: "v0.4.18", changeLog: "Fork updater"},
+		{name: "release manifest", payload: `{"version":"v0.4.19","change_log":"Fork updater"}`, version: "v0.4.19", changeLog: "Fork updater"},
 		{name: "legacy API", payload: `{"data":{"version":"0.4.15","change_log":"Upstream"}}`, version: "0.4.15", changeLog: "Upstream"},
-		{name: "GitHub API", payload: `{"tag_name":"v0.4.18","body":"Release body"}`, version: "v0.4.18", changeLog: "Release body"},
+		{name: "GitHub API", payload: `{"tag_name":"v0.4.19","body":"Release body"}`, version: "v0.4.19", changeLog: "Release body"},
 	}
 
 	for _, test := range tests {

--- a/service/system.go
+++ b/service/system.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	net2 "net"
 	"os"
+	osExec "os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -35,7 +36,7 @@ import (
 )
 
 type SystemService interface {
-	UpdateSystemVersion(version string)
+	UpdateSystemVersion(version string) error
 	GetSystemConfigDebug() []string
 	GetCasaOSLogs(lineNumber int) string
 	UpdateAssist()
@@ -370,17 +371,43 @@ func (c *systemService) GetNet(physics bool) []string {
 	}
 }
 
-func (s *systemService) UpdateSystemVersion(version string) {
+func (s *systemService) UpdateSystemVersion(version string) error {
 	keyName := "casa_version:" + resolveUpdateVersionURL()
 	Cache.Delete(keyName)
-	if file.Exists(config.AppInfo.LogPath + "/upgrade.log") {
-		os.Remove(config.AppInfo.LogPath + "/upgrade.log")
-	}
-	file.CreateFile(config.AppInfo.LogPath + "/upgrade.log")
-	go command.OnlyExec("curl -fsSL " + shellQuote(resolveUpdateInstallerURL()) + " | bash")
 
-	// s.log.Error(config.AppInfo.ProjectPath + "/shell/tool.sh -r " + version)
-	// s.log.Error(command2.ExecResultStr(config.AppInfo.ProjectPath + "/shell/tool.sh -r " + version))
+	logPath := filepath.Join(config.AppInfo.LogPath, "upgrade.log")
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		return fmt.Errorf("prepare update log: %w", err)
+	}
+
+	return startDetachedUpdate(resolveUpdateInstallerURL(), logPath, version)
+}
+
+func startDetachedUpdate(installerURL, logPath, version string) error {
+	args := detachedUpdateArgs(installerURL, logPath, version)
+	output, err := osExec.Command("systemd-run", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("start detached update: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func detachedUpdateArgs(installerURL, logPath, version string) []string {
+	return []string{
+		"--quiet",
+		"--collect",
+		"--unit=casaos-update",
+		"--property=Type=exec",
+		"--setenv=CASAOS_INSTALLER_DETACHED=1",
+		"--description=CasaOS update " + version,
+		"/bin/bash",
+		"-c",
+		detachedUpdateCommand(installerURL, logPath),
+	}
+}
+
+func detachedUpdateCommand(installerURL, logPath string) string {
+	return "set -o pipefail; exec >> " + shellQuote(logPath) + " 2>&1; curl -fsSL " + shellQuote(installerURL) + " | /bin/bash"
 }
 
 func resolveUpdateInstallerURL() string {

--- a/service/system.go
+++ b/service/system.go
@@ -371,22 +371,28 @@ func (c *systemService) GetNet(physics bool) []string {
 }
 
 func (s *systemService) UpdateSystemVersion(version string) {
-	keyName := "casa_version"
+	keyName := "casa_version:" + resolveUpdateVersionURL()
 	Cache.Delete(keyName)
 	if file.Exists(config.AppInfo.LogPath + "/upgrade.log") {
 		os.Remove(config.AppInfo.LogPath + "/upgrade.log")
 	}
 	file.CreateFile(config.AppInfo.LogPath + "/upgrade.log")
-	// go command2.OnlyExec("curl -fsSL https://raw.githubusercontent.com/LinkLeong/casaos-alpha/main/update.sh | bash")
-	if len(config.ServerInfo.UpdateUrl) > 0 {
-		go command.OnlyExec("curl -fsSL " + config.ServerInfo.UpdateUrl + " | bash")
-	} else {
-		osRelease, _ := file.ReadOSRelease()
-		go command.OnlyExec("curl -fsSL https://get.casaos.io/update?t=" + osRelease["MANUFACTURER"] + " | bash")
-	}
+	go command.OnlyExec("curl -fsSL " + shellQuote(resolveUpdateInstallerURL()) + " | bash")
 
 	// s.log.Error(config.AppInfo.ProjectPath + "/shell/tool.sh -r " + version)
 	// s.log.Error(command2.ExecResultStr(config.AppInfo.ProjectPath + "/shell/tool.sh -r " + version))
+}
+
+func resolveUpdateInstallerURL() string {
+	value := strings.TrimSpace(config.ServerInfo.UpdateUrl)
+	if validHTTPSURL(value) {
+		return value
+	}
+	return common.FORK_UPDATE_URL
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func (s *systemService) UpdateAssist() {

--- a/service/system_update_test.go
+++ b/service/system_update_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/IceWhaleTech/CasaOS/common"
@@ -27,5 +28,31 @@ func TestShellQuote(t *testing.T) {
 	want := `'https://example.com/a'"'"'b'`
 	if got != want {
 		t.Fatalf("shellQuote() = %q, want %q", got, want)
+	}
+}
+
+func TestDetachedUpdateCommand(t *testing.T) {
+	got := detachedUpdateCommand("https://example.com/a'b", "/var/log/casaos/upgrade.log")
+	want := `set -o pipefail; exec >> '/var/log/casaos/upgrade.log' 2>&1; curl -fsSL 'https://example.com/a'"'"'b' | /bin/bash`
+	if got != want {
+		t.Fatalf("detachedUpdateCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestDetachedUpdateArgs(t *testing.T) {
+	got := detachedUpdateArgs("https://example.com/install.sh", "/var/log/casaos/upgrade.log", "v0.4.19")
+	want := []string{
+		"--quiet",
+		"--collect",
+		"--unit=casaos-update",
+		"--property=Type=exec",
+		"--setenv=CASAOS_INSTALLER_DETACHED=1",
+		"--description=CasaOS update v0.4.19",
+		"/bin/bash",
+		"-c",
+		"set -o pipefail; exec >> '/var/log/casaos/upgrade.log' 2>&1; curl -fsSL 'https://example.com/install.sh' | /bin/bash",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("detachedUpdateArgs() = %#v, want %#v", got, want)
 	}
 }

--- a/service/system_update_test.go
+++ b/service/system_update_test.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/IceWhaleTech/CasaOS/common"
+	"github.com/IceWhaleTech/CasaOS/pkg/config"
+)
+
+func TestResolveUpdateInstallerURL(t *testing.T) {
+	original := config.ServerInfo.UpdateUrl
+	t.Cleanup(func() { config.ServerInfo.UpdateUrl = original })
+
+	config.ServerInfo.UpdateUrl = "https://example.com/install.sh"
+	if got := resolveUpdateInstallerURL(); got != "https://example.com/install.sh" {
+		t.Fatalf("resolveUpdateInstallerURL() = %q", got)
+	}
+
+	config.ServerInfo.UpdateUrl = "http://example.com/install.sh"
+	if got := resolveUpdateInstallerURL(); got != common.FORK_UPDATE_URL {
+		t.Fatalf("resolveUpdateInstallerURL() fallback = %q", got)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	got := shellQuote("https://example.com/a'b")
+	want := `'https://example.com/a'"'"'b'`
+	if got != want {
+		t.Fatalf("shellQuote() = %q, want %q", got, want)
+	}
+}

--- a/service/system_update_test.go
+++ b/service/system_update_test.go
@@ -40,14 +40,14 @@ func TestDetachedUpdateCommand(t *testing.T) {
 }
 
 func TestDetachedUpdateArgs(t *testing.T) {
-	got := detachedUpdateArgs("https://example.com/install.sh", "/var/log/casaos/upgrade.log", "v0.4.19")
+	got := detachedUpdateArgs("https://example.com/install.sh", "/var/log/casaos/upgrade.log", "v0.4.20")
 	want := []string{
 		"--quiet",
 		"--collect",
 		"--unit=casaos-update",
 		"--property=Type=exec",
 		"--setenv=CASAOS_INSTALLER_DETACHED=1",
-		"--description=CasaOS update v0.4.19",
+		"--description=CasaOS update v0.4.20",
 		"/bin/bash",
 		"-c",
 		"set -o pipefail; exec >> '/var/log/casaos/upgrade.log' 2>&1; curl -fsSL 'https://example.com/install.sh' | /bin/bash",


### PR DESCRIPTION
## Summary\n\n- advance the fork updater fallback to v0.4.25\n- document the external-only merged storage behavior and release notes\n- preserve the existing upstream-compatible update URLs\n\nThe corresponding installer bundle is published at https://github.com/alvins82/CasaOS-Install/releases/tag/v0.4.25 and has been applied successfully through the dashboard update endpoint on the Ubuntu 26 ARM64 test VM.